### PR TITLE
update servicecontext to take chunk_size_limit

### DIFF
--- a/slack_bot/slack_bot/models/llama.py
+++ b/slack_bot/slack_bot/models/llama.py
@@ -119,6 +119,7 @@ class Llama(ResponseModel):
             llm_predictor=llm_predictor,
             embed_model=embed_model,
             prompt_helper=prompt_helper,
+            chunk_size_limit=chunk_size_limit,
         )
 
         self.index = GPTVectorStoreIndex.from_documents(


### PR DESCRIPTION
one line change to add chunk_size_limit argument to ServiceContext - seems to avoid previous errors that were coming up like `got a larger chunk overlap (...) than chunk size (...), should be smaller.`