### PR TITLE
nb for updating index

### DIFF
--- a/data_processing/insert_to_existing_LlamaIndex.ipynb
+++ b/data_processing/insert_to_existing_LlamaIndex.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6873e049-12b1-4e8b-a5fc-99ccd0555bee",
+   "metadata": {},
+   "source": [
+    "# Inserting to existing index\n",
+    "\n",
+    "Assumes that we want to update an existing index (but are unable to isolate the new documents up-front)\n",
+    "\n",
+    "To do this we:\n",
+    "1. Load the existing index\n",
+    "2. Load the new data file (which includes data we've already indexed as well as some new docs :( )\n",
+    "3. Work out overlap and isolate new documents\n",
+    "4. Add new documents to index\n",
+    "5. Save new index\n",
+    "\n",
+    "TODO:\n",
+    "- extend to identify data to delete (outdated pages)\n",
+    "- auto identify CHUNK_SIZE_LIMIT if possible"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d911a23e-fce3-4941-a823-10a40828ff68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7968b50-f84a-4a7f-b30a-e19e03e0556d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"OPENAI_API_KEY\"] = \"foo\" # dummy key to make the service context happy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fba59ab2-1a0d-463e-adf9-5a7adf0a7dc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from tqdm.auto import tqdm\n",
+    "\n",
+    "from llama_index import Document, LangchainEmbedding\n",
+    "from llama_index.storage import StorageContext\n",
+    "from llama_index import ServiceContext\n",
+    "from llama_index import load_index_from_storage\n",
+    "from langchain.embeddings.huggingface import HuggingFaceEmbeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09c1150f-5225-4252-a222-2d530d42fd5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ALL_DATA_INDEX_FPATH = os.path.abspath(\"./data/llama_index_indices/all_data\") # existing index we want to add to\n",
+    "NEW_INDEX_FPATH = os.path.abspath(\"./data/llama_index_indices/all_data_new\") # output path for newly constructed index\n",
+    "CHUNK_SIZE_LIMIT = 2048 # CHECK THIS! known existing value - needs to match existing input but not sure whether this is recoverable just from index files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92205849-4784-4233-b706-0ff1075c9326",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "website_data = \"./data/public/turingacuk-no-boilerplate.csv\" # our file containing new data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f084153-4490-4ca4-9dfb-195535d25f07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "storage_context = StorageContext.from_defaults(persist_dir=ALL_DATA_INDEX_FPATH)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9e7b018-24b7-4fa7-978d-5c9619ad4430",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hfemb = HuggingFaceEmbeddings()\n",
+    "embed_model = LangchainEmbedding(hfemb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef03fdac-99f5-4f3f-a487-c412e5b842f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "service_context = ServiceContext.from_defaults(\n",
+    "            llm_predictor=None,\n",
+    "            embed_model=embed_model,\n",
+    "            prompt_helper=None,\n",
+    "            chunk_size_limit=CHUNK_SIZE_LIMIT,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4ff7688-c0bc-4396-9661-dd3d4895a2a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load a single index\n",
+    "index = load_index_from_storage(storage_context=storage_context, service_context=service_context)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d6368b3-5688-4590-9e14-c2efd6906e5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(website_data).dropna() # load our new data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08320c1a-29b6-46bf-8399-9f1bfbf5bdc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert df to Documents\n",
+    "candidate_docs = [Document(row[\"body\"], extra_info={\"filename\": row[\"url\"]}) for i, row in df.iterrows()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a3fb093-e70f-4184-be34-c48f306cd917",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Sequence\n",
+    "from llama_index.storage.docstore import DocumentStore\n",
+    "\n",
+    "def get_hashset_for_docstore(docstore: DocumentStore) -> set[str]:\n",
+    "    docs = docstore.docs\n",
+    "    return set([docs[d].doc_hash for d in docs])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56550f15-ebf8-4eba-b084-15a330adea82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hashes = get_hashset_for_docstore(docstore=index.docstore)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4d2c225-cf3a-4bea-83ac-518c6cbd3e49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# don't want to insert docs we already have hashes for in doc store\n",
+    "# however, the docstore hashes will be after chunking... so we won't catch them all here\n",
+    "# doing this first for speed and will try a more complex approach on remaining docs\n",
+    "maybe_new_docs = [doc for doc in candidate_docs if doc.doc_hash not in hashes]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd7991de-1dd2-46b8-b149-2806a86bbcf0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(candidate_docs), len(maybe_new_docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70401e56-bce6-4874-a8f2-8d0132134e6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs_chunked = [service_context.node_parser.get_nodes_from_documents([doc]) for doc in tqdm(maybe_new_docs)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd2ac80c-0eb6-4bad-a443-989d16f88adb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO collapse this into a single comprehension?\n",
+    "# for each doc's chunks, check if these hashes exist already in the index \n",
+    "exists = [all([node.doc_hash in hashes for node in sublist]) for sublist in docs_chunked]\n",
+    "# use this to filter to actually new docs\n",
+    "new_docs = [doc for i, doc in enumerate(maybe_new_docs) if not exists[i]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c896b27-ecb1-4c4f-9fc7-acc68849a498",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(new_docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "074fbd74-b705-4d1f-ab42-f8e64eabd354",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for doc in tqdm(new_docs):\n",
+    "    index.insert(document=doc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a1e3013-d200-4a43-8bb5-f7439c40f6c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index.storage_context.persist(persist_dir=NEW_INDEX_FPATH)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af26da41-e3f2-4652-a006-2205a8ce6dda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls -lh $ALL_DATA_INDEX_FPATH"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4de1eea9-02a5-49e2-9255-7ea590da6089",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls -lh $NEW_INDEX_FPATH"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Assumes that we want to update an existing index (but are unable to isolate the new documents up-front)

To do this we:

    Load the existing index
    Load the new data file (which includes data we've already indexed as well as some new docs :( )
    Work out overlap and isolate new documents
    Add new documents to index
    Save new index

TODO and not covered by PR

    extend to identify data to delete (outdated pages)
    auto identify CHUNK_SIZE_LIMIT if possible
