### PR TITLE
Add ability to clear chat history

### DIFF
--- a/slack_bot/slack_bot/bot/bot.py
+++ b/slack_bot/slack_bot/bot/bot.py
@@ -71,7 +71,7 @@ class Bot(AsyncSocketModeRequestListener):
                 command = req.payload["command"]
                 user_id = req.payload["user_id"]
 
-                if command == "/clear_history":
+                if command.startswith("/clear_history"):
                     if self.model.mode == "chat":
                         logging.info(f"Clearing {user_id}'s history")
                         if self.model.chat_engine.get(user_id) is not None:


### PR DESCRIPTION
This PR:
- Adds the ability to use the `/clear_history` command in slack to clear the chat history. 

Unsure what happens if you use a non-llama_index model. 
Will need to address this.