### PR TITLE
Fix #143: Add data creation CLI

### DIFF
--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -24,6 +24,8 @@ jobs:
             image: ghcr.io/${{ github.repository }}_reginald
           - dockerfile: docker/slack_bot/Dockerfile
             image: ghcr.io/${{ github.repository }}_slackbot
+          - dockerfile: docker/create_index/Dockerfile
+            image: ghcr.io/${{ github.repository }}_create_index
     permissions:
       packages: write
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,6 @@ cython_debug/
 
 # Pulumi
 azure/*/.secrets
+azure/*.secrets
 azure/*/Pulumi.*.yaml
 data/llama_index_indices/all_data/

--- a/docker/create_index/Dockerfile
+++ b/docker/create_index/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11.4
+
+WORKDIR /app
+
+# Setup Python prerequisites
+RUN pip3 install --upgrade pip poetry setuptools wheel
+
+# Build Python project
+COPY reginald reginald
+COPY pyproject.toml .
+COPY README.md .
+RUN poetry install
+
+CMD ["poetry", "run", "reginald_create_index"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "accelerate"
-version = "0.23.0"
+version = "0.25.0"
 description = "Accelerate"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "accelerate-0.23.0-py3-none-any.whl", hash = "sha256:fba5065ff4e7c8f0a39df50785023703cd9bf8388073aa13c6457920f3bc5225"},
-    {file = "accelerate-0.23.0.tar.gz", hash = "sha256:2139d219fa9a37773c4279c9afebe9f681f2f29e85a29b0be8d76257bd8e4abe"},
+    {file = "accelerate-0.25.0-py3-none-any.whl", hash = "sha256:c7bb817eb974bba0ff3ea1ba0f24d55afb86d50e3d4fe98d6922dc69cf2ccff1"},
+    {file = "accelerate-0.25.0.tar.gz", hash = "sha256:ecf55b0ab278a1dac8539dde0d276977aff04683f07ede73eaf02478538576a1"},
 ]
 
 [package.dependencies]
@@ -17,6 +17,7 @@ numpy = ">=1.17"
 packaging = ">=20.0"
 psutil = "*"
 pyyaml = "*"
+safetensors = ">=0.3.1"
 torch = ">=1.10.0"
 
 [package.extras]
@@ -26,7 +27,7 @@ rich = ["rich"]
 sagemaker = ["sagemaker"]
 test-dev = ["bitsandbytes", "datasets", "deepspeed", "evaluate", "scikit-learn", "scipy", "timm", "tqdm", "transformers"]
 test-prod = ["parameterized", "pytest", "pytest-subtests", "pytest-xdist"]
-test-trackers = ["comet-ml", "tensorboard", "wandb"]
+test-trackers = ["comet-ml", "dvclive", "tensorboard", "wandb"]
 testing = ["bitsandbytes", "datasets", "deepspeed", "evaluate", "parameterized", "pytest", "pytest-subtests", "pytest-xdist", "scikit-learn", "scipy", "timm", "tqdm", "transformers"]
 
 [[package]]
@@ -730,25 +731,27 @@ dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (
 
 [[package]]
 name = "datasets"
-version = "2.14.4"
+version = "2.16.1"
 description = "HuggingFace community-driven open-source library of datasets"
-optional = true
+optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "datasets-2.14.4-py3-none-any.whl", hash = "sha256:29336bd316a7d827ccd4da2236596279b20ca2ac78f64c04c9483da7cbc2459b"},
-    {file = "datasets-2.14.4.tar.gz", hash = "sha256:ef29c2b5841de488cd343cfc26ab979bff77efa4d2285af51f1ad7db5c46a83b"},
+    {file = "datasets-2.16.1-py3-none-any.whl", hash = "sha256:fafa300c78ff92d521473a3d47d60c2d3e0d6046212cc03ceb6caf6550737257"},
+    {file = "datasets-2.16.1.tar.gz", hash = "sha256:ad3215e9b1984d1de4fda2123bc7319ccbdf1e17d0c3d5590d13debff308a080"},
 ]
 
 [package.dependencies]
 aiohttp = "*"
 dill = ">=0.3.0,<0.3.8"
-fsspec = {version = ">=2021.11.1", extras = ["http"]}
-huggingface-hub = ">=0.14.0,<1.0.0"
+filelock = "*"
+fsspec = {version = ">=2023.1.0,<=2023.10.0", extras = ["http"]}
+huggingface-hub = ">=0.19.4"
 multiprocess = "*"
 numpy = ">=1.17"
 packaging = "*"
 pandas = "*"
 pyarrow = ">=8.0.0"
+pyarrow-hotfix = "*"
 pyyaml = ">=5.1"
 requests = ">=2.19.0"
 tqdm = ">=4.62.1"
@@ -758,15 +761,15 @@ xxhash = "*"
 apache-beam = ["apache-beam (>=2.26.0,<2.44.0)"]
 audio = ["librosa", "soundfile (>=0.12.1)"]
 benchmarks = ["tensorflow (==2.12.0)", "torch (==2.0.1)", "transformers (==4.30.1)"]
-dev = ["Pillow (>=6.2.1)", "absl-py", "apache-beam (>=2.26.0,<2.44.0)", "black (>=23.1,<24.0)", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "joblib (<1.3.0)", "joblibspark", "librosa", "lz4", "py7zr", "pyspark (>=3.4)", "pytest", "pytest-datadir", "pytest-xdist", "pyyaml (>=5.3.1)", "rarfile (>=4.0)", "ruff (>=0.0.241)", "s3fs", "s3fs (>=2021.11.1)", "soundfile (>=0.12.1)", "sqlalchemy (<2.0.0)", "tensorflow (>=2.2.0,!=2.6.0,!=2.6.1)", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "tensorflow-macos", "tiktoken", "torch", "transformers", "zstandard"]
+dev = ["Pillow (>=6.2.1)", "absl-py", "apache-beam (>=2.26.0,<2.44.0)", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "jax (>=0.3.14)", "jaxlib (>=0.3.14)", "joblib (<1.3.0)", "joblibspark", "librosa", "lz4", "py7zr", "pyspark (>=3.4)", "pytest", "pytest-datadir", "pytest-xdist", "rarfile (>=4.0)", "ruff (>=0.1.5)", "s3fs", "s3fs (>=2021.11.1)", "soundfile (>=0.12.1)", "sqlalchemy (<2.0.0)", "tensorflow (>=2.2.0,!=2.6.0,!=2.6.1)", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "tensorflow-macos", "tiktoken", "torch", "torch (>=2.0.0)", "transformers", "typing-extensions (>=4.6.1)", "zstandard"]
 docs = ["s3fs", "tensorflow (>=2.2.0,!=2.6.0,!=2.6.1)", "tensorflow-macos", "torch", "transformers"]
-jax = ["jax (>=0.2.8,!=0.3.2,<=0.3.25)", "jaxlib (>=0.1.65,<=0.3.25)"]
+jax = ["jax (>=0.3.14)", "jaxlib (>=0.3.14)"]
 metrics-tests = ["Werkzeug (>=1.0.1)", "accelerate", "bert-score (>=0.3.6)", "jiwer", "langdetect", "mauve-text", "nltk", "requests-file (>=1.5.1)", "rouge-score", "sacrebleu", "sacremoses", "scikit-learn", "scipy", "sentencepiece", "seqeval", "six (>=1.15.0,<1.16.0)", "spacy (>=3.0.0)", "texttable (>=1.6.3)", "tldextract", "tldextract (>=3.1.0)", "toml (>=0.10.1)", "typer (<0.5.0)"]
-quality = ["black (>=23.1,<24.0)", "pyyaml (>=5.3.1)", "ruff (>=0.0.241)"]
+quality = ["ruff (>=0.1.5)"]
 s3 = ["s3fs"]
 tensorflow = ["tensorflow (>=2.2.0,!=2.6.0,!=2.6.1)", "tensorflow-macos"]
 tensorflow-gpu = ["tensorflow-gpu (>=2.2.0,!=2.6.0,!=2.6.1)"]
-tests = ["Pillow (>=6.2.1)", "absl-py", "apache-beam (>=2.26.0,<2.44.0)", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "joblib (<1.3.0)", "joblibspark", "librosa", "lz4", "py7zr", "pyspark (>=3.4)", "pytest", "pytest-datadir", "pytest-xdist", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "soundfile (>=0.12.1)", "sqlalchemy (<2.0.0)", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "tensorflow-macos", "tiktoken", "torch", "transformers", "zstandard"]
+tests = ["Pillow (>=6.2.1)", "absl-py", "apache-beam (>=2.26.0,<2.44.0)", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "jax (>=0.3.14)", "jaxlib (>=0.3.14)", "joblib (<1.3.0)", "joblibspark", "librosa", "lz4", "py7zr", "pyspark (>=3.4)", "pytest", "pytest-datadir", "pytest-xdist", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "soundfile (>=0.12.1)", "sqlalchemy (<2.0.0)", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "tensorflow-macos", "tiktoken", "torch (>=2.0.0)", "transformers", "typing-extensions (>=4.6.1)", "zstandard"]
 torch = ["torch"]
 vision = ["Pillow (>=6.2.1)"]
 
@@ -840,7 +843,7 @@ dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
 name = "dill"
 version = "0.3.7"
 description = "serialize all of Python"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "dill-0.3.7-py3-none-any.whl", hash = "sha256:76b122c08ef4ce2eedcd4d1abd8e641114bfc6c2867f49f3c41facf65bf19f5e"},
@@ -1872,21 +1875,22 @@ files = [
 
 [[package]]
 name = "langchain"
-version = "0.0.329"
+version = "0.0.353"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
 files = [
-    {file = "langchain-0.0.329-py3-none-any.whl", hash = "sha256:5f3e884991271e8b55eda4c63a11105dcd7da119682ce0e3d5d1385b3a4103d2"},
-    {file = "langchain-0.0.329.tar.gz", hash = "sha256:488f3cb68a587696f136d4f01f97df8d8270e295b3cc56158057dab0f61f4166"},
+    {file = "langchain-0.0.353-py3-none-any.whl", hash = "sha256:54cac8b74fbefacddcdf0c443619a7331d6b59fe94fa2a48a4d7da2b59cf1f63"},
+    {file = "langchain-0.0.353.tar.gz", hash = "sha256:a095ea819f13a3606ced699182a8369eb2d77034ec8c913983675d6dd9a98196"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.8.3,<4.0.0"
-anyio = "<4.0"
 dataclasses-json = ">=0.5.7,<0.7"
 jsonpatch = ">=1.33,<2.0"
-langsmith = ">=0.0.52,<0.1.0"
+langchain-community = ">=0.0.2,<0.1"
+langchain-core = ">=0.1.4,<0.2"
+langsmith = ">=0.0.70,<0.1.0"
 numpy = ">=1,<2"
 pydantic = ">=1,<3"
 PyYAML = ">=5.3"
@@ -1895,29 +1899,78 @@ SQLAlchemy = ">=1.4,<3"
 tenacity = ">=8.1.0,<9.0.0"
 
 [package.extras]
-all = ["O365 (>=2.0.26,<3.0.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "amadeus (>=8.1.0)", "arxiv (>=1.4,<2.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "awadb (>=0.3.9,<0.4.0)", "azure-ai-formrecognizer (>=3.2.1,<4.0.0)", "azure-ai-vision (>=0.11.1b1,<0.12.0)", "azure-cognitiveservices-speech (>=1.28.0,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "beautifulsoup4 (>=4,<5)", "clarifai (>=9.1.0)", "clickhouse-connect (>=0.5.14,<0.6.0)", "cohere (>=4,<5)", "deeplake (>=3.8.3,<4.0.0)", "docarray[hnswlib] (>=0.32.0,<0.33.0)", "duckduckgo-search (>=3.8.3,<4.0.0)", "elasticsearch (>=8,<9)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "google-api-python-client (==2.70.0)", "google-auth (>=2.18.1,<3.0.0)", "google-search-results (>=2,<3)", "gptcache (>=0.1.7)", "html2text (>=2020.1.16,<2021.0.0)", "huggingface_hub (>=0,<1)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "lancedb (>=0.1,<0.2)", "langkit (>=0.0.6,<0.1.0)", "lark (>=1.1.5,<2.0.0)", "librosa (>=0.10.0.post2,<0.11.0)", "lxml (>=4.9.2,<5.0.0)", "manifest-ml (>=0.0.1,<0.0.2)", "marqo (>=1.2.4,<2.0.0)", "momento (>=1.10.1,<2.0.0)", "nebula3-python (>=3.4.0,<4.0.0)", "neo4j (>=5.8.1,<6.0.0)", "networkx (>=2.6.3,<4)", "nlpcloud (>=1,<2)", "nltk (>=3,<4)", "nomic (>=1.0.43,<2.0.0)", "openai (>=0,<1)", "openlm (>=0.0.5,<0.0.6)", "opensearch-py (>=2.0.0,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pexpect (>=4.8.0,<5.0.0)", "pgvector (>=0.1.6,<0.2.0)", "pinecone-client (>=2,<3)", "pinecone-text (>=0.4.2,<0.5.0)", "psycopg2-binary (>=2.9.5,<3.0.0)", "pymongo (>=4.3.3,<5.0.0)", "pyowm (>=3.3.0,<4.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pytesseract (>=0.3.10,<0.4.0)", "python-arango (>=7.5.9,<8.0.0)", "pyvespa (>=0.33.0,<0.34.0)", "qdrant-client (>=1.3.1,<2.0.0)", "rdflib (>=6.3.2,<7.0.0)", "redis (>=4,<5)", "requests-toolbelt (>=1.0.0,<2.0.0)", "sentence-transformers (>=2,<3)", "singlestoredb (>=0.7.1,<0.8.0)", "tensorflow-text (>=2.11.0,<3.0.0)", "tigrisdb (>=1.0.0b6,<2.0.0)", "tiktoken (>=0.3.2,<0.6.0)", "torch (>=1,<3)", "transformers (>=4,<5)", "weaviate-client (>=3,<4)", "wikipedia (>=1,<2)", "wolframalpha (==5.0.0)"]
-azure = ["azure-ai-formrecognizer (>=3.2.1,<4.0.0)", "azure-ai-vision (>=0.11.1b1,<0.12.0)", "azure-cognitiveservices-speech (>=1.28.0,<2.0.0)", "azure-core (>=1.26.4,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "azure-search-documents (==11.4.0b8)", "openai (>=0,<1)"]
+azure = ["azure-ai-formrecognizer (>=3.2.1,<4.0.0)", "azure-ai-textanalytics (>=5.3.0,<6.0.0)", "azure-ai-vision (>=0.11.1b1,<0.12.0)", "azure-cognitiveservices-speech (>=1.28.0,<2.0.0)", "azure-core (>=1.26.4,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "azure-search-documents (==11.4.0b8)", "openai (<2)"]
 clarifai = ["clarifai (>=9.1.0)"]
 cli = ["typer (>=0.9.0,<0.10.0)"]
 cohere = ["cohere (>=4,<5)"]
 docarray = ["docarray[hnswlib] (>=0.32.0,<0.33.0)"]
 embeddings = ["sentence-transformers (>=2,<3)"]
-extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.3.11,<0.4.0)", "arxiv (>=1.4,<2.0)", "assemblyai (>=0.17.0,<0.18.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "beautifulsoup4 (>=4,<5)", "bibtexparser (>=1.4.0,<2.0.0)", "cassio (>=0.1.0,<0.2.0)", "chardet (>=5.1.0,<6.0.0)", "dashvector (>=1.0.1,<2.0.0)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "feedparser (>=6.0.10,<7.0.0)", "fireworks-ai (>=0.6.0,<0.7.0)", "geopandas (>=0.13.1,<0.14.0)", "gitpython (>=3.1.32,<4.0.0)", "google-cloud-documentai (>=2.20.1,<3.0.0)", "gql (>=3.4.1,<4.0.0)", "html2text (>=2020.1.16,<2021.0.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "jsonschema (>1)", "lxml (>=4.9.2,<5.0.0)", "markdownify (>=0.11.6,<0.12.0)", "motor (>=3.3.1,<4.0.0)", "mwparserfromhell (>=0.6.4,<0.7.0)", "mwxml (>=0.3.3,<0.4.0)", "newspaper3k (>=0.2.8,<0.3.0)", "numexpr (>=2.8.6,<3.0.0)", "openai (>=0,<1)", "openapi-pydantic (>=0.3.2,<0.4.0)", "pandas (>=2.0.1,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pgvector (>=0.1.6,<0.2.0)", "psychicapi (>=0.8.0,<0.9.0)", "py-trello (>=0.19.0,<0.20.0)", "pymupdf (>=1.22.3,<2.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pypdfium2 (>=4.10.0,<5.0.0)", "pyspark (>=3.4.0,<4.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "rapidfuzz (>=3.1.1,<4.0.0)", "rapidocr-onnxruntime (>=1.3.2,<2.0.0)", "requests-toolbelt (>=1.0.0,<2.0.0)", "rspace_client (>=2.5.0,<3.0.0)", "scikit-learn (>=1.2.2,<2.0.0)", "sqlite-vss (>=0.1.2,<0.2.0)", "streamlit (>=1.18.0,<2.0.0)", "sympy (>=1.12,<2.0)", "telethon (>=1.28.5,<2.0.0)", "timescale-vector (>=0.0.1,<0.0.2)", "tqdm (>=4.48.0)", "upstash-redis (>=0.15.0,<0.16.0)", "xata (>=1.0.0a7,<2.0.0)", "xmltodict (>=0.13.0,<0.14.0)"]
+extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.3.11,<0.4.0)", "arxiv (>=1.4,<2.0)", "assemblyai (>=0.17.0,<0.18.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "beautifulsoup4 (>=4,<5)", "bibtexparser (>=1.4.0,<2.0.0)", "cassio (>=0.1.0,<0.2.0)", "chardet (>=5.1.0,<6.0.0)", "cohere (>=4,<5)", "couchbase (>=4.1.9,<5.0.0)", "dashvector (>=1.0.1,<2.0.0)", "databricks-vectorsearch (>=0.21,<0.22)", "datasets (>=2.15.0,<3.0.0)", "dgml-utils (>=0.3.0,<0.4.0)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "feedparser (>=6.0.10,<7.0.0)", "fireworks-ai (>=0.9.0,<0.10.0)", "geopandas (>=0.13.1,<0.14.0)", "gitpython (>=3.1.32,<4.0.0)", "google-cloud-documentai (>=2.20.1,<3.0.0)", "gql (>=3.4.1,<4.0.0)", "hologres-vector (>=0.0.6,<0.0.7)", "html2text (>=2020.1.16,<2021.0.0)", "javelin-sdk (>=0.1.8,<0.2.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "jsonschema (>1)", "lxml (>=4.9.2,<5.0.0)", "markdownify (>=0.11.6,<0.12.0)", "motor (>=3.3.1,<4.0.0)", "msal (>=1.25.0,<2.0.0)", "mwparserfromhell (>=0.6.4,<0.7.0)", "mwxml (>=0.3.3,<0.4.0)", "newspaper3k (>=0.2.8,<0.3.0)", "numexpr (>=2.8.6,<3.0.0)", "openai (<2)", "openapi-pydantic (>=0.3.2,<0.4.0)", "pandas (>=2.0.1,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pgvector (>=0.1.6,<0.2.0)", "praw (>=7.7.1,<8.0.0)", "psychicapi (>=0.8.0,<0.9.0)", "py-trello (>=0.19.0,<0.20.0)", "pymupdf (>=1.22.3,<2.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pypdfium2 (>=4.10.0,<5.0.0)", "pyspark (>=3.4.0,<4.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "rapidfuzz (>=3.1.1,<4.0.0)", "rapidocr-onnxruntime (>=1.3.2,<2.0.0)", "requests-toolbelt (>=1.0.0,<2.0.0)", "rspace_client (>=2.5.0,<3.0.0)", "scikit-learn (>=1.2.2,<2.0.0)", "sqlite-vss (>=0.1.2,<0.2.0)", "streamlit (>=1.18.0,<2.0.0)", "sympy (>=1.12,<2.0)", "telethon (>=1.28.5,<2.0.0)", "timescale-vector (>=0.0.1,<0.0.2)", "tqdm (>=4.48.0)", "upstash-redis (>=0.15.0,<0.16.0)", "xata (>=1.0.0a7,<2.0.0)", "xmltodict (>=0.13.0,<0.14.0)"]
 javascript = ["esprima (>=4.0.1,<5.0.0)"]
-llms = ["clarifai (>=9.1.0)", "cohere (>=4,<5)", "huggingface_hub (>=0,<1)", "manifest-ml (>=0.0.1,<0.0.2)", "nlpcloud (>=1,<2)", "openai (>=0,<1)", "openlm (>=0.0.5,<0.0.6)", "torch (>=1,<3)", "transformers (>=4,<5)"]
-openai = ["openai (>=0,<1)", "tiktoken (>=0.3.2,<0.6.0)"]
+llms = ["clarifai (>=9.1.0)", "cohere (>=4,<5)", "huggingface_hub (>=0,<1)", "manifest-ml (>=0.0.1,<0.0.2)", "nlpcloud (>=1,<2)", "openai (<2)", "openlm (>=0.0.5,<0.0.6)", "torch (>=1,<3)", "transformers (>=4,<5)"]
+openai = ["openai (<2)", "tiktoken (>=0.3.2,<0.6.0)"]
 qdrant = ["qdrant-client (>=1.3.1,<2.0.0)"]
 text-helpers = ["chardet (>=5.1.0,<6.0.0)"]
 
 [[package]]
+name = "langchain-community"
+version = "0.0.7"
+description = "Community contributed LangChain integrations."
+optional = false
+python-versions = ">=3.8.1,<4.0"
+files = [
+    {file = "langchain_community-0.0.7-py3-none-any.whl", hash = "sha256:468af187bfffe753426cc4548132824be7df9404d38ceef2f873087290d8ff0e"},
+    {file = "langchain_community-0.0.7.tar.gz", hash = "sha256:cfbeb25cac7dff3c021f3c82aa243fc80f80082d6f6fdcc79daf36b1408828cc"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.8.3,<4.0.0"
+dataclasses-json = ">=0.5.7,<0.7"
+langchain-core = ">=0.1,<0.2"
+langsmith = ">=0.0.63,<0.1.0"
+numpy = ">=1,<2"
+PyYAML = ">=5.3"
+requests = ">=2,<3"
+SQLAlchemy = ">=1.4,<3"
+tenacity = ">=8.1.0,<9.0.0"
+
+[package.extras]
+cli = ["typer (>=0.9.0,<0.10.0)"]
+extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.3.11,<0.4.0)", "arxiv (>=1.4,<2.0)", "assemblyai (>=0.17.0,<0.18.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "azure-ai-documentintelligence (>=1.0.0b1,<2.0.0)", "beautifulsoup4 (>=4,<5)", "bibtexparser (>=1.4.0,<2.0.0)", "cassio (>=0.1.0,<0.2.0)", "chardet (>=5.1.0,<6.0.0)", "cohere (>=4,<5)", "dashvector (>=1.0.1,<2.0.0)", "databricks-vectorsearch (>=0.21,<0.22)", "datasets (>=2.15.0,<3.0.0)", "dgml-utils (>=0.3.0,<0.4.0)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "feedparser (>=6.0.10,<7.0.0)", "fireworks-ai (>=0.9.0,<0.10.0)", "geopandas (>=0.13.1,<0.14.0)", "gitpython (>=3.1.32,<4.0.0)", "google-cloud-documentai (>=2.20.1,<3.0.0)", "gql (>=3.4.1,<4.0.0)", "gradientai (>=1.4.0,<2.0.0)", "hologres-vector (>=0.0.6,<0.0.7)", "html2text (>=2020.1.16,<2021.0.0)", "javelin-sdk (>=0.1.8,<0.2.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "jsonschema (>1)", "lxml (>=4.9.2,<5.0.0)", "markdownify (>=0.11.6,<0.12.0)", "motor (>=3.3.1,<4.0.0)", "msal (>=1.25.0,<2.0.0)", "mwparserfromhell (>=0.6.4,<0.7.0)", "mwxml (>=0.3.3,<0.4.0)", "newspaper3k (>=0.2.8,<0.3.0)", "numexpr (>=2.8.6,<3.0.0)", "openai (<2)", "openapi-pydantic (>=0.3.2,<0.4.0)", "oracle-ads (>=2.9.1,<3.0.0)", "pandas (>=2.0.1,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pgvector (>=0.1.6,<0.2.0)", "praw (>=7.7.1,<8.0.0)", "psychicapi (>=0.8.0,<0.9.0)", "py-trello (>=0.19.0,<0.20.0)", "pymupdf (>=1.22.3,<2.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pypdfium2 (>=4.10.0,<5.0.0)", "pyspark (>=3.4.0,<4.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "rapidfuzz (>=3.1.1,<4.0.0)", "rapidocr-onnxruntime (>=1.3.2,<2.0.0)", "requests-toolbelt (>=1.0.0,<2.0.0)", "rspace_client (>=2.5.0,<3.0.0)", "scikit-learn (>=1.2.2,<2.0.0)", "sqlite-vss (>=0.1.2,<0.2.0)", "streamlit (>=1.18.0,<2.0.0)", "sympy (>=1.12,<2.0)", "telethon (>=1.28.5,<2.0.0)", "timescale-vector (>=0.0.1,<0.0.2)", "tqdm (>=4.48.0)", "upstash-redis (>=0.15.0,<0.16.0)", "xata (>=1.0.0a7,<2.0.0)", "xmltodict (>=0.13.0,<0.14.0)"]
+
+[[package]]
+name = "langchain-core"
+version = "0.1.4"
+description = "Building applications with LLMs through composability"
+optional = false
+python-versions = ">=3.8.1,<4.0"
+files = [
+    {file = "langchain_core-0.1.4-py3-none-any.whl", hash = "sha256:c62bd362d5abf5359436a99b29629e12a4d1ede9f1704dc958cdb8530a791efd"},
+    {file = "langchain_core-0.1.4.tar.gz", hash = "sha256:f700138689c9014e23d3c29796a892dccf7f2a42901cb8817671823e1a24724c"},
+]
+
+[package.dependencies]
+anyio = ">=3,<5"
+jsonpatch = ">=1.33,<2.0"
+langsmith = ">=0.0.63,<0.1.0"
+packaging = ">=23.2,<24.0"
+pydantic = ">=1,<3"
+PyYAML = ">=5.3"
+requests = ">=2,<3"
+tenacity = ">=8.1.0,<9.0.0"
+
+[package.extras]
+extended-testing = ["jinja2 (>=3,<4)"]
+
+[[package]]
 name = "langsmith"
-version = "0.0.52"
+version = "0.0.75"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = ">=3.8.1,<4.0"
 files = [
-    {file = "langsmith-0.0.52-py3-none-any.whl", hash = "sha256:d02a0ade5a53b36143084e57003ed38ccbdf5fc15a5a0eb14f8989ceaee0b807"},
-    {file = "langsmith-0.0.52.tar.gz", hash = "sha256:1dc29082d257deea1859cb22c53d9481ca5c4a37f3af40c0f9d300fb8adc91db"},
+    {file = "langsmith-0.0.75-py3-none-any.whl", hash = "sha256:3e008854204c5eaae007f34c7e249059218605689c385c037f6a40cac044833b"},
+    {file = "langsmith-0.0.75.tar.gz", hash = "sha256:3fd44c58bd53cb9366af3de129c7f11b6947914f1bb598a585240df0e2c566eb"},
 ]
 
 [package.dependencies]
@@ -1965,13 +2018,13 @@ retrying = "*"
 
 [[package]]
 name = "llama-index"
-version = "0.8.57"
+version = "0.8.62"
 description = "Interface between LLMs and your data"
 optional = false
 python-versions = ">=3.8.1,<3.12"
 files = [
-    {file = "llama_index-0.8.57-py3-none-any.whl", hash = "sha256:eb5ecb114e755091bfa4a625b86cc509f958a8b8c5a428b16c8e004141f99a4c"},
-    {file = "llama_index-0.8.57.tar.gz", hash = "sha256:6dbdcf2731696429303d1e91edc1c11e3a4a47a3c89ec2b31a85d16d38b4313b"},
+    {file = "llama_index-0.8.62-py3-none-any.whl", hash = "sha256:5ea95e1a1ec0f759e29093c92cdfd3f1c780d3c638a306b86aa22993ab15ce80"},
+    {file = "llama_index-0.8.62.tar.gz", hash = "sha256:c0db90f49ca8a11777b14e2a72921bef1edbf21ac5564651911999a9913f14ae"},
 ]
 
 [package.dependencies]
@@ -1983,7 +2036,7 @@ langchain = ">=0.0.303"
 nest-asyncio = ">=1.5.8,<2.0.0"
 nltk = ">=3.8.1,<4.0.0"
 numpy = "*"
-openai = ">=0.26.4"
+openai = "<1"
 pandas = "*"
 SQLAlchemy = {version = ">=1.4.49", extras = ["asyncio"]}
 tenacity = ">=8.2.0,<9.0.0"
@@ -1995,7 +2048,7 @@ urllib3 = "<2"
 [package.extras]
 local-models = ["optimum[onnxruntime] (>=1.13.2,<2.0.0)", "sentencepiece (>=0.1.99,<0.2.0)", "transformers[torch] (>=4.34.0,<5.0.0)"]
 postgres = ["asyncpg (>=0.28.0,<0.29.0)", "pgvector (>=0.1.0,<0.2.0)", "psycopg-binary (>=3.1.12,<4.0.0)"]
-query-tools = ["guidance (>=0.0.64,<0.0.65)", "jsonpath-ng (>=1.6.0,<2.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "scikit-learn (<1.3.0)", "spacy (>=3.7.1,<4.0.0)"]
+query-tools = ["guidance (>=0.0.64,<0.0.65)", "jsonpath-ng (>=1.6.0,<2.0.0)", "lm-format-enforcer (>=0.4.3,<0.5.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "scikit-learn (<1.3.0)", "spacy (>=3.7.1,<4.0.0)"]
 
 [[package]]
 name = "markdown-it-py"
@@ -2303,7 +2356,7 @@ files = [
 name = "multiprocess"
 version = "0.70.15"
 description = "better multiprocessing and multithreading in Python"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "multiprocess-0.70.15-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:aa36c7ed16f508091438687fe9baa393a7a8e206731d321e443745e743a0d4e5"},
@@ -2629,13 +2682,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.1"
+version = "23.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
-    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
 
 [[package]]
@@ -3003,7 +3056,7 @@ tests = ["pytest"]
 name = "pyarrow"
 version = "14.0.1"
 description = "Python library for Apache Arrow"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "pyarrow-14.0.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:96d64e5ba7dceb519a955e5eeb5c9adcfd63f73a56aea4722e2cc81364fc567a"},
@@ -3046,6 +3099,17 @@ files = [
 
 [package.dependencies]
 numpy = ">=1.16.6"
+
+[[package]]
+name = "pyarrow-hotfix"
+version = "0.6"
+description = ""
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "pyarrow_hotfix-0.6-py3-none-any.whl", hash = "sha256:dcc9ae2d220dff0083be6a9aa8e0cdee5182ad358d4931fce825c545e5c89178"},
+    {file = "pyarrow_hotfix-0.6.tar.gz", hash = "sha256:79d3e030f7ff890d408a100ac16d6f00b14d44a502d7897cd9fc3e3a534e9945"},
+]
 
 [[package]]
 name = "pycparser"
@@ -4973,7 +5037,7 @@ files = [
 name = "xxhash"
 version = "3.3.0"
 description = "Python binding for xxHash"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "xxhash-3.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:70ef7288d1cb1ad16e02d101ea43bb0e392d985d60b9b0035aee80663530960d"},
@@ -5159,4 +5223,4 @@ llama-index-notebooks = ["bitsandbytes", "gradio", "ipykernel", "nbconvert"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "af98ffbca50c5256df5a8f92440734f00f0fc7b88a2606dccb021166a13d3952"
+content-hash = "db376d3dd39f4f37198ce82e2f6af8cc1cfc7dd1f613ff065e9b85c5cce3a519"

--- a/poetry.lock
+++ b/poetry.lock
@@ -733,7 +733,7 @@ dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (
 name = "datasets"
 version = "2.16.1"
 description = "HuggingFace community-driven open-source library of datasets"
-optional = false
+optional = true
 python-versions = ">=3.8.0"
 files = [
     {file = "datasets-2.16.1-py3-none-any.whl", hash = "sha256:fafa300c78ff92d521473a3d47d60c2d3e0d6046212cc03ceb6caf6550737257"},
@@ -843,7 +843,7 @@ dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
 name = "dill"
 version = "0.3.7"
 description = "serialize all of Python"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "dill-0.3.7-py3-none-any.whl", hash = "sha256:76b122c08ef4ce2eedcd4d1abd8e641114bfc6c2867f49f3c41facf65bf19f5e"},
@@ -1875,22 +1875,21 @@ files = [
 
 [[package]]
 name = "langchain"
-version = "0.0.353"
+version = "0.0.329"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
 files = [
-    {file = "langchain-0.0.353-py3-none-any.whl", hash = "sha256:54cac8b74fbefacddcdf0c443619a7331d6b59fe94fa2a48a4d7da2b59cf1f63"},
-    {file = "langchain-0.0.353.tar.gz", hash = "sha256:a095ea819f13a3606ced699182a8369eb2d77034ec8c913983675d6dd9a98196"},
+    {file = "langchain-0.0.329-py3-none-any.whl", hash = "sha256:5f3e884991271e8b55eda4c63a11105dcd7da119682ce0e3d5d1385b3a4103d2"},
+    {file = "langchain-0.0.329.tar.gz", hash = "sha256:488f3cb68a587696f136d4f01f97df8d8270e295b3cc56158057dab0f61f4166"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.8.3,<4.0.0"
+anyio = "<4.0"
 dataclasses-json = ">=0.5.7,<0.7"
 jsonpatch = ">=1.33,<2.0"
-langchain-community = ">=0.0.2,<0.1"
-langchain-core = ">=0.1.4,<0.2"
-langsmith = ">=0.0.70,<0.1.0"
+langsmith = ">=0.0.52,<0.1.0"
 numpy = ">=1,<2"
 pydantic = ">=1,<3"
 PyYAML = ">=5.3"
@@ -1899,68 +1898,19 @@ SQLAlchemy = ">=1.4,<3"
 tenacity = ">=8.1.0,<9.0.0"
 
 [package.extras]
-azure = ["azure-ai-formrecognizer (>=3.2.1,<4.0.0)", "azure-ai-textanalytics (>=5.3.0,<6.0.0)", "azure-ai-vision (>=0.11.1b1,<0.12.0)", "azure-cognitiveservices-speech (>=1.28.0,<2.0.0)", "azure-core (>=1.26.4,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "azure-search-documents (==11.4.0b8)", "openai (<2)"]
+all = ["O365 (>=2.0.26,<3.0.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "amadeus (>=8.1.0)", "arxiv (>=1.4,<2.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "awadb (>=0.3.9,<0.4.0)", "azure-ai-formrecognizer (>=3.2.1,<4.0.0)", "azure-ai-vision (>=0.11.1b1,<0.12.0)", "azure-cognitiveservices-speech (>=1.28.0,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "beautifulsoup4 (>=4,<5)", "clarifai (>=9.1.0)", "clickhouse-connect (>=0.5.14,<0.6.0)", "cohere (>=4,<5)", "deeplake (>=3.8.3,<4.0.0)", "docarray[hnswlib] (>=0.32.0,<0.33.0)", "duckduckgo-search (>=3.8.3,<4.0.0)", "elasticsearch (>=8,<9)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "google-api-python-client (==2.70.0)", "google-auth (>=2.18.1,<3.0.0)", "google-search-results (>=2,<3)", "gptcache (>=0.1.7)", "html2text (>=2020.1.16,<2021.0.0)", "huggingface_hub (>=0,<1)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "lancedb (>=0.1,<0.2)", "langkit (>=0.0.6,<0.1.0)", "lark (>=1.1.5,<2.0.0)", "librosa (>=0.10.0.post2,<0.11.0)", "lxml (>=4.9.2,<5.0.0)", "manifest-ml (>=0.0.1,<0.0.2)", "marqo (>=1.2.4,<2.0.0)", "momento (>=1.10.1,<2.0.0)", "nebula3-python (>=3.4.0,<4.0.0)", "neo4j (>=5.8.1,<6.0.0)", "networkx (>=2.6.3,<4)", "nlpcloud (>=1,<2)", "nltk (>=3,<4)", "nomic (>=1.0.43,<2.0.0)", "openai (>=0,<1)", "openlm (>=0.0.5,<0.0.6)", "opensearch-py (>=2.0.0,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pexpect (>=4.8.0,<5.0.0)", "pgvector (>=0.1.6,<0.2.0)", "pinecone-client (>=2,<3)", "pinecone-text (>=0.4.2,<0.5.0)", "psycopg2-binary (>=2.9.5,<3.0.0)", "pymongo (>=4.3.3,<5.0.0)", "pyowm (>=3.3.0,<4.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pytesseract (>=0.3.10,<0.4.0)", "python-arango (>=7.5.9,<8.0.0)", "pyvespa (>=0.33.0,<0.34.0)", "qdrant-client (>=1.3.1,<2.0.0)", "rdflib (>=6.3.2,<7.0.0)", "redis (>=4,<5)", "requests-toolbelt (>=1.0.0,<2.0.0)", "sentence-transformers (>=2,<3)", "singlestoredb (>=0.7.1,<0.8.0)", "tensorflow-text (>=2.11.0,<3.0.0)", "tigrisdb (>=1.0.0b6,<2.0.0)", "tiktoken (>=0.3.2,<0.6.0)", "torch (>=1,<3)", "transformers (>=4,<5)", "weaviate-client (>=3,<4)", "wikipedia (>=1,<2)", "wolframalpha (==5.0.0)"]
+azure = ["azure-ai-formrecognizer (>=3.2.1,<4.0.0)", "azure-ai-vision (>=0.11.1b1,<0.12.0)", "azure-cognitiveservices-speech (>=1.28.0,<2.0.0)", "azure-core (>=1.26.4,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "azure-search-documents (==11.4.0b8)", "openai (>=0,<1)"]
 clarifai = ["clarifai (>=9.1.0)"]
 cli = ["typer (>=0.9.0,<0.10.0)"]
 cohere = ["cohere (>=4,<5)"]
 docarray = ["docarray[hnswlib] (>=0.32.0,<0.33.0)"]
 embeddings = ["sentence-transformers (>=2,<3)"]
-extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.3.11,<0.4.0)", "arxiv (>=1.4,<2.0)", "assemblyai (>=0.17.0,<0.18.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "beautifulsoup4 (>=4,<5)", "bibtexparser (>=1.4.0,<2.0.0)", "cassio (>=0.1.0,<0.2.0)", "chardet (>=5.1.0,<6.0.0)", "cohere (>=4,<5)", "couchbase (>=4.1.9,<5.0.0)", "dashvector (>=1.0.1,<2.0.0)", "databricks-vectorsearch (>=0.21,<0.22)", "datasets (>=2.15.0,<3.0.0)", "dgml-utils (>=0.3.0,<0.4.0)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "feedparser (>=6.0.10,<7.0.0)", "fireworks-ai (>=0.9.0,<0.10.0)", "geopandas (>=0.13.1,<0.14.0)", "gitpython (>=3.1.32,<4.0.0)", "google-cloud-documentai (>=2.20.1,<3.0.0)", "gql (>=3.4.1,<4.0.0)", "hologres-vector (>=0.0.6,<0.0.7)", "html2text (>=2020.1.16,<2021.0.0)", "javelin-sdk (>=0.1.8,<0.2.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "jsonschema (>1)", "lxml (>=4.9.2,<5.0.0)", "markdownify (>=0.11.6,<0.12.0)", "motor (>=3.3.1,<4.0.0)", "msal (>=1.25.0,<2.0.0)", "mwparserfromhell (>=0.6.4,<0.7.0)", "mwxml (>=0.3.3,<0.4.0)", "newspaper3k (>=0.2.8,<0.3.0)", "numexpr (>=2.8.6,<3.0.0)", "openai (<2)", "openapi-pydantic (>=0.3.2,<0.4.0)", "pandas (>=2.0.1,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pgvector (>=0.1.6,<0.2.0)", "praw (>=7.7.1,<8.0.0)", "psychicapi (>=0.8.0,<0.9.0)", "py-trello (>=0.19.0,<0.20.0)", "pymupdf (>=1.22.3,<2.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pypdfium2 (>=4.10.0,<5.0.0)", "pyspark (>=3.4.0,<4.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "rapidfuzz (>=3.1.1,<4.0.0)", "rapidocr-onnxruntime (>=1.3.2,<2.0.0)", "requests-toolbelt (>=1.0.0,<2.0.0)", "rspace_client (>=2.5.0,<3.0.0)", "scikit-learn (>=1.2.2,<2.0.0)", "sqlite-vss (>=0.1.2,<0.2.0)", "streamlit (>=1.18.0,<2.0.0)", "sympy (>=1.12,<2.0)", "telethon (>=1.28.5,<2.0.0)", "timescale-vector (>=0.0.1,<0.0.2)", "tqdm (>=4.48.0)", "upstash-redis (>=0.15.0,<0.16.0)", "xata (>=1.0.0a7,<2.0.0)", "xmltodict (>=0.13.0,<0.14.0)"]
+extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.3.11,<0.4.0)", "arxiv (>=1.4,<2.0)", "assemblyai (>=0.17.0,<0.18.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "beautifulsoup4 (>=4,<5)", "bibtexparser (>=1.4.0,<2.0.0)", "cassio (>=0.1.0,<0.2.0)", "chardet (>=5.1.0,<6.0.0)", "dashvector (>=1.0.1,<2.0.0)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "feedparser (>=6.0.10,<7.0.0)", "fireworks-ai (>=0.6.0,<0.7.0)", "geopandas (>=0.13.1,<0.14.0)", "gitpython (>=3.1.32,<4.0.0)", "google-cloud-documentai (>=2.20.1,<3.0.0)", "gql (>=3.4.1,<4.0.0)", "html2text (>=2020.1.16,<2021.0.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "jsonschema (>1)", "lxml (>=4.9.2,<5.0.0)", "markdownify (>=0.11.6,<0.12.0)", "motor (>=3.3.1,<4.0.0)", "mwparserfromhell (>=0.6.4,<0.7.0)", "mwxml (>=0.3.3,<0.4.0)", "newspaper3k (>=0.2.8,<0.3.0)", "numexpr (>=2.8.6,<3.0.0)", "openai (>=0,<1)", "openapi-pydantic (>=0.3.2,<0.4.0)", "pandas (>=2.0.1,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pgvector (>=0.1.6,<0.2.0)", "psychicapi (>=0.8.0,<0.9.0)", "py-trello (>=0.19.0,<0.20.0)", "pymupdf (>=1.22.3,<2.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pypdfium2 (>=4.10.0,<5.0.0)", "pyspark (>=3.4.0,<4.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "rapidfuzz (>=3.1.1,<4.0.0)", "rapidocr-onnxruntime (>=1.3.2,<2.0.0)", "requests-toolbelt (>=1.0.0,<2.0.0)", "rspace_client (>=2.5.0,<3.0.0)", "scikit-learn (>=1.2.2,<2.0.0)", "sqlite-vss (>=0.1.2,<0.2.0)", "streamlit (>=1.18.0,<2.0.0)", "sympy (>=1.12,<2.0)", "telethon (>=1.28.5,<2.0.0)", "timescale-vector (>=0.0.1,<0.0.2)", "tqdm (>=4.48.0)", "upstash-redis (>=0.15.0,<0.16.0)", "xata (>=1.0.0a7,<2.0.0)", "xmltodict (>=0.13.0,<0.14.0)"]
 javascript = ["esprima (>=4.0.1,<5.0.0)"]
-llms = ["clarifai (>=9.1.0)", "cohere (>=4,<5)", "huggingface_hub (>=0,<1)", "manifest-ml (>=0.0.1,<0.0.2)", "nlpcloud (>=1,<2)", "openai (<2)", "openlm (>=0.0.5,<0.0.6)", "torch (>=1,<3)", "transformers (>=4,<5)"]
-openai = ["openai (<2)", "tiktoken (>=0.3.2,<0.6.0)"]
+llms = ["clarifai (>=9.1.0)", "cohere (>=4,<5)", "huggingface_hub (>=0,<1)", "manifest-ml (>=0.0.1,<0.0.2)", "nlpcloud (>=1,<2)", "openai (>=0,<1)", "openlm (>=0.0.5,<0.0.6)", "torch (>=1,<3)", "transformers (>=4,<5)"]
+openai = ["openai (>=0,<1)", "tiktoken (>=0.3.2,<0.6.0)"]
 qdrant = ["qdrant-client (>=1.3.1,<2.0.0)"]
 text-helpers = ["chardet (>=5.1.0,<6.0.0)"]
-
-[[package]]
-name = "langchain-community"
-version = "0.0.7"
-description = "Community contributed LangChain integrations."
-optional = false
-python-versions = ">=3.8.1,<4.0"
-files = [
-    {file = "langchain_community-0.0.7-py3-none-any.whl", hash = "sha256:468af187bfffe753426cc4548132824be7df9404d38ceef2f873087290d8ff0e"},
-    {file = "langchain_community-0.0.7.tar.gz", hash = "sha256:cfbeb25cac7dff3c021f3c82aa243fc80f80082d6f6fdcc79daf36b1408828cc"},
-]
-
-[package.dependencies]
-aiohttp = ">=3.8.3,<4.0.0"
-dataclasses-json = ">=0.5.7,<0.7"
-langchain-core = ">=0.1,<0.2"
-langsmith = ">=0.0.63,<0.1.0"
-numpy = ">=1,<2"
-PyYAML = ">=5.3"
-requests = ">=2,<3"
-SQLAlchemy = ">=1.4,<3"
-tenacity = ">=8.1.0,<9.0.0"
-
-[package.extras]
-cli = ["typer (>=0.9.0,<0.10.0)"]
-extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.3.11,<0.4.0)", "arxiv (>=1.4,<2.0)", "assemblyai (>=0.17.0,<0.18.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "azure-ai-documentintelligence (>=1.0.0b1,<2.0.0)", "beautifulsoup4 (>=4,<5)", "bibtexparser (>=1.4.0,<2.0.0)", "cassio (>=0.1.0,<0.2.0)", "chardet (>=5.1.0,<6.0.0)", "cohere (>=4,<5)", "dashvector (>=1.0.1,<2.0.0)", "databricks-vectorsearch (>=0.21,<0.22)", "datasets (>=2.15.0,<3.0.0)", "dgml-utils (>=0.3.0,<0.4.0)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "feedparser (>=6.0.10,<7.0.0)", "fireworks-ai (>=0.9.0,<0.10.0)", "geopandas (>=0.13.1,<0.14.0)", "gitpython (>=3.1.32,<4.0.0)", "google-cloud-documentai (>=2.20.1,<3.0.0)", "gql (>=3.4.1,<4.0.0)", "gradientai (>=1.4.0,<2.0.0)", "hologres-vector (>=0.0.6,<0.0.7)", "html2text (>=2020.1.16,<2021.0.0)", "javelin-sdk (>=0.1.8,<0.2.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "jsonschema (>1)", "lxml (>=4.9.2,<5.0.0)", "markdownify (>=0.11.6,<0.12.0)", "motor (>=3.3.1,<4.0.0)", "msal (>=1.25.0,<2.0.0)", "mwparserfromhell (>=0.6.4,<0.7.0)", "mwxml (>=0.3.3,<0.4.0)", "newspaper3k (>=0.2.8,<0.3.0)", "numexpr (>=2.8.6,<3.0.0)", "openai (<2)", "openapi-pydantic (>=0.3.2,<0.4.0)", "oracle-ads (>=2.9.1,<3.0.0)", "pandas (>=2.0.1,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pgvector (>=0.1.6,<0.2.0)", "praw (>=7.7.1,<8.0.0)", "psychicapi (>=0.8.0,<0.9.0)", "py-trello (>=0.19.0,<0.20.0)", "pymupdf (>=1.22.3,<2.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pypdfium2 (>=4.10.0,<5.0.0)", "pyspark (>=3.4.0,<4.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "rapidfuzz (>=3.1.1,<4.0.0)", "rapidocr-onnxruntime (>=1.3.2,<2.0.0)", "requests-toolbelt (>=1.0.0,<2.0.0)", "rspace_client (>=2.5.0,<3.0.0)", "scikit-learn (>=1.2.2,<2.0.0)", "sqlite-vss (>=0.1.2,<0.2.0)", "streamlit (>=1.18.0,<2.0.0)", "sympy (>=1.12,<2.0)", "telethon (>=1.28.5,<2.0.0)", "timescale-vector (>=0.0.1,<0.0.2)", "tqdm (>=4.48.0)", "upstash-redis (>=0.15.0,<0.16.0)", "xata (>=1.0.0a7,<2.0.0)", "xmltodict (>=0.13.0,<0.14.0)"]
-
-[[package]]
-name = "langchain-core"
-version = "0.1.4"
-description = "Building applications with LLMs through composability"
-optional = false
-python-versions = ">=3.8.1,<4.0"
-files = [
-    {file = "langchain_core-0.1.4-py3-none-any.whl", hash = "sha256:c62bd362d5abf5359436a99b29629e12a4d1ede9f1704dc958cdb8530a791efd"},
-    {file = "langchain_core-0.1.4.tar.gz", hash = "sha256:f700138689c9014e23d3c29796a892dccf7f2a42901cb8817671823e1a24724c"},
-]
-
-[package.dependencies]
-anyio = ">=3,<5"
-jsonpatch = ">=1.33,<2.0"
-langsmith = ">=0.0.63,<0.1.0"
-packaging = ">=23.2,<24.0"
-pydantic = ">=1,<3"
-PyYAML = ">=5.3"
-requests = ">=2,<3"
-tenacity = ">=8.1.0,<9.0.0"
-
-[package.extras]
-extended-testing = ["jinja2 (>=3,<4)"]
 
 [[package]]
 name = "langsmith"
@@ -2356,7 +2306,7 @@ files = [
 name = "multiprocess"
 version = "0.70.15"
 description = "better multiprocessing and multithreading in Python"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "multiprocess-0.70.15-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:aa36c7ed16f508091438687fe9baa393a7a8e206731d321e443745e743a0d4e5"},
@@ -3056,7 +3006,7 @@ tests = ["pytest"]
 name = "pyarrow"
 version = "14.0.1"
 description = "Python library for Apache Arrow"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "pyarrow-14.0.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:96d64e5ba7dceb519a955e5eeb5c9adcfd63f73a56aea4722e2cc81364fc567a"},
@@ -3104,7 +3054,7 @@ numpy = ">=1.16.6"
 name = "pyarrow-hotfix"
 version = "0.6"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "pyarrow_hotfix-0.6-py3-none-any.whl", hash = "sha256:dcc9ae2d220dff0083be6a9aa8e0cdee5182ad358d4931fce825c545e5c89178"},
@@ -5037,7 +4987,7 @@ files = [
 name = "xxhash"
 version = "3.3.0"
 description = "Python binding for xxHash"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "xxhash-3.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:70ef7288d1cb1ad16e02d101ea43bb0e392d985d60b9b0035aee80663530960d"},
@@ -5223,4 +5173,4 @@ llama-index-notebooks = ["bitsandbytes", "gradio", "ipykernel", "nbconvert"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "db376d3dd39f4f37198ce82e2f6af8cc1cfc7dd1f613ff065e9b85c5cce3a519"
+content-hash = "76c060f98f8117b35f39e54eebb577ccc72c9d67be481dbccc25eb968d3f05a2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1398,39 +1398,40 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "0.18.0"
+version = "1.0.2"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-0.18.0-py3-none-any.whl", hash = "sha256:adc5398ee0a476567bf87467063ee63584a8bce86078bf748e48754f60202ced"},
-    {file = "httpcore-0.18.0.tar.gz", hash = "sha256:13b5e5cd1dca1a6636a6aaea212b19f4f85cd88c366a2b82304181b769aab3c9"},
+    {file = "httpcore-1.0.2-py3-none-any.whl", hash = "sha256:096cc05bca73b8e459a1fc3dcf585148f63e534eae4339559c9b8a8d6399acc7"},
+    {file = "httpcore-1.0.2.tar.gz", hash = "sha256:9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535"},
 ]
 
 [package.dependencies]
-anyio = ">=3.0,<5.0"
 certifi = "*"
 h11 = ">=0.13,<0.15"
-sniffio = "==1.*"
 
 [package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<0.23.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.25.0"
+version = "0.26.0"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.25.0-py3-none-any.whl", hash = "sha256:181ea7f8ba3a82578be86ef4171554dd45fec26a02556a744db029a0a27b7100"},
-    {file = "httpx-0.25.0.tar.gz", hash = "sha256:47ecda285389cb32bb2691cc6e069e3ab0205956f681c5b2ad2325719751d875"},
+    {file = "httpx-0.26.0-py3-none-any.whl", hash = "sha256:8915f5a3627c4d47b73e8202457cb28f1266982d1159bd5779d86a80c0eab1cd"},
+    {file = "httpx-0.26.0.tar.gz", hash = "sha256:451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf"},
 ]
 
 [package.dependencies]
+anyio = "*"
 certifi = "*"
-httpcore = ">=0.18.0,<0.19.0"
+httpcore = "==1.*"
 idna = "*"
 sniffio = "*"
 
@@ -5173,4 +5174,4 @@ llama-index-notebooks = ["bitsandbytes", "gradio", "ipykernel", "nbconvert"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "76c060f98f8117b35f39e54eebb577ccc72c9d67be481dbccc25eb968d3f05a2"
+content-hash = "2a3cf8bcb829a00ee01878e4de5002e9771f9f25e2f906ee7addd32b38ef73b8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1179,13 +1179,13 @@ test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mypy", "pre-commit"
 
 [[package]]
 name = "gradio"
-version = "3.44.4"
+version = "4.12.0"
 description = "Python library for easily interacting with trained machine learning models"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "gradio-3.44.4-py3-none-any.whl", hash = "sha256:803566d7b4b10d30b73e14d063302f496e8e165d539112c01dc9ad85f31e3b16"},
-    {file = "gradio-3.44.4.tar.gz", hash = "sha256:e094e12bd5e9914f50c8563d596c25433edba932eff279518a43613fbe219416"},
+    {file = "gradio-4.12.0-py3-none-any.whl", hash = "sha256:a8e18e8c7004574df26e1ae1d99bb20a6921693f9d922978848c25b31d3f7f5b"},
+    {file = "gradio-4.12.0.tar.gz", hash = "sha256:ea982139d3cee6542c18d8f52295395b19124c14e6e78d28e19417d6fd6f838c"},
 ]
 
 [package.dependencies]
@@ -1193,9 +1193,9 @@ aiofiles = ">=22.0,<24.0"
 altair = ">=4.2.0,<6.0"
 fastapi = "*"
 ffmpy = "*"
-gradio-client = "0.5.1"
+gradio-client = "0.8.0"
 httpx = "*"
-huggingface-hub = ">=0.14.0"
+huggingface-hub = ">=0.19.3"
 importlib-resources = ">=1.3,<7.0"
 jinja2 = "<4.0"
 markupsafe = ">=2.0,<3.0"
@@ -1205,36 +1205,35 @@ orjson = ">=3.0,<4.0"
 packaging = "*"
 pandas = ">=1.0,<3.0"
 pillow = ">=8.0,<11.0"
-pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<3.0.0"
+pydantic = ">=2.0"
 pydub = "*"
 python-multipart = "*"
 pyyaml = ">=5.0,<7.0"
-requests = ">=2.0,<3.0"
 semantic-version = ">=2.0,<3.0"
+tomlkit = "0.12.0"
+typer = {version = ">=0.9,<1.0", extras = ["all"]}
 typing-extensions = ">=4.0,<5.0"
 uvicorn = ">=0.14.0"
-websockets = ">=10.0,<12.0"
 
 [package.extras]
 oauth = ["authlib", "itsdangerous"]
 
 [[package]]
 name = "gradio-client"
-version = "0.5.1"
+version = "0.8.0"
 description = "Python library for easily interacting with trained machine learning models"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "gradio_client-0.5.1-py3-none-any.whl", hash = "sha256:e8899878e63c8b9d03dffd2dfb63a96ef43d71f659108931a7d2233a33d67a26"},
-    {file = "gradio_client-0.5.1.tar.gz", hash = "sha256:d60a00deabaea47002acbcbd0d471acd25a5beac51127a42817cd5b7ece66e05"},
+    {file = "gradio_client-0.8.0-py3-none-any.whl", hash = "sha256:0d817e9ff72fc1ba0866c11612a2b1c995d370ab7ea0fbf2bd0649e6da49ad76"},
+    {file = "gradio_client-0.8.0.tar.gz", hash = "sha256:19714dbc3d86f64d6725a90c4270ec22376f0c3b48271389bd81ede86a733cda"},
 ]
 
 [package.dependencies]
 fsspec = "*"
 httpx = "*"
-huggingface-hub = ">=0.13.0"
+huggingface-hub = ">=0.19.3"
 packaging = "*"
-requests = ">=2.0,<3.0"
 typing-extensions = ">=4.0,<5.0"
 websockets = ">=10.0,<12.0"
 
@@ -1376,7 +1375,7 @@ protobuf = ["grpcio-tools (>=1.56.2)"]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
@@ -1398,7 +1397,7 @@ files = [
 name = "httpcore"
 version = "0.18.0"
 description = "A minimal low-level HTTP client."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "httpcore-0.18.0-py3-none-any.whl", hash = "sha256:adc5398ee0a476567bf87467063ee63584a8bce86078bf748e48754f60202ced"},
@@ -1419,7 +1418,7 @@ socks = ["socksio (==1.*)"]
 name = "httpx"
 version = "0.25.0"
 description = "The next generation HTTP client."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "httpx-0.25.0-py3-none-any.whl", hash = "sha256:181ea7f8ba3a82578be86ef4171554dd45fec26a02556a744db029a0a27b7100"},
@@ -1440,18 +1439,18 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "huggingface-hub"
-version = "0.17.2"
+version = "0.20.1"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "huggingface_hub-0.17.2-py3-none-any.whl", hash = "sha256:fc4a36640b2b51dced0da37a18420572145a0dd528f46715afe6c1f955cc8533"},
-    {file = "huggingface_hub-0.17.2.tar.gz", hash = "sha256:51b0257ff75b422d3cb0662db799c7a03fdc72b8f84a09ce3ff7655dca1958b2"},
+    {file = "huggingface_hub-0.20.1-py3-none-any.whl", hash = "sha256:ecfdea395a8bc68cd160106c5bd857f7e010768d95f9e1862a779010cc304831"},
+    {file = "huggingface_hub-0.20.1.tar.gz", hash = "sha256:8c88c4c3c8853e22f2dfb4d84c3d493f4e1af52fb3856a90e1eeddcf191ddbb1"},
 ]
 
 [package.dependencies]
 filelock = "*"
-fsspec = "*"
+fsspec = ">=2023.5.0"
 packaging = ">=20.9"
 pyyaml = ">=5.1"
 requests = "*"
@@ -1459,17 +1458,16 @@ tqdm = ">=4.42.1"
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
-all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "black (==23.7)", "gradio", "jedi", "mypy (==1.5.1)", "numpy", "pydantic (<2.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-vcr", "pytest-xdist", "ruff (>=0.0.241)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "urllib3 (<2.0)"]
+all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "mypy (==1.5.1)", "numpy", "pydantic (>1.1,<2.0)", "pydantic (>1.1,<3.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.1.3)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
 cli = ["InquirerPy (==0.3.4)"]
-dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "black (==23.7)", "gradio", "jedi", "mypy (==1.5.1)", "numpy", "pydantic (<2.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-vcr", "pytest-xdist", "ruff (>=0.0.241)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "urllib3 (<2.0)"]
-docs = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "black (==23.7)", "gradio", "hf-doc-builder", "jedi", "mypy (==1.5.1)", "numpy", "pydantic (<2.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-vcr", "pytest-xdist", "ruff (>=0.0.241)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "urllib3 (<2.0)", "watchdog"]
+dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "mypy (==1.5.1)", "numpy", "pydantic (>1.1,<2.0)", "pydantic (>1.1,<3.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.1.3)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
 fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
-inference = ["aiohttp", "pydantic (<2.0)"]
-quality = ["black (==23.7)", "mypy (==1.5.1)", "ruff (>=0.0.241)"]
+inference = ["aiohttp", "pydantic (>1.1,<2.0)", "pydantic (>1.1,<3.0)"]
+quality = ["mypy (==1.5.1)", "ruff (>=0.1.3)"]
 tensorflow = ["graphviz", "pydot", "tensorflow"]
-testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "numpy", "pydantic (<2.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
+testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "numpy", "pydantic (>1.1,<2.0)", "pydantic (>1.1,<3.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
 torch = ["torch"]
-typing = ["pydantic (<2.0)", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3"]
+typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
 
 [[package]]
 name = "identify"
@@ -2000,6 +1998,30 @@ postgres = ["asyncpg (>=0.28.0,<0.29.0)", "pgvector (>=0.1.0,<0.2.0)", "psycopg-
 query-tools = ["guidance (>=0.0.64,<0.0.65)", "jsonpath-ng (>=1.6.0,<2.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "scikit-learn (<1.3.0)", "spacy (>=3.7.1,<4.0.0)"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -2154,6 +2176,17 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "mistune"
@@ -3593,6 +3626,24 @@ files = [
 six = ">=1.7.0"
 
 [[package]]
+name = "rich"
+version = "13.7.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = true
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
+    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "rpds-py"
 version = "0.10.3"
 description = "Python bindings to Rust's persistent data structures (rpds)"
@@ -3996,6 +4047,17 @@ rich = ["rich"]
 test = ["pytest", "rich", "virtualenv (>20)"]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -4272,57 +4334,129 @@ test = ["flake8", "isort", "pytest"]
 
 [[package]]
 name = "tokenizers"
-version = "0.13.3"
-description = "Fast and Customizable Tokenizers"
+version = "0.15.0"
+description = ""
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "tokenizers-0.13.3-cp310-cp310-macosx_10_11_x86_64.whl", hash = "sha256:f3835c5be51de8c0a092058a4d4380cb9244fb34681fd0a295fbf0a52a5fdf33"},
-    {file = "tokenizers-0.13.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:4ef4c3e821730f2692489e926b184321e887f34fb8a6b80b8096b966ba663d07"},
-    {file = "tokenizers-0.13.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5fd1a6a25353e9aa762e2aae5a1e63883cad9f4e997c447ec39d071020459bc"},
-    {file = "tokenizers-0.13.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee0b1b311d65beab83d7a41c56a1e46ab732a9eed4460648e8eb0bd69fc2d059"},
-    {file = "tokenizers-0.13.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ef4215284df1277dadbcc5e17d4882bda19f770d02348e73523f7e7d8b8d396"},
-    {file = "tokenizers-0.13.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4d53976079cff8a033f778fb9adca2d9d69d009c02fa2d71a878b5f3963ed30"},
-    {file = "tokenizers-0.13.3-cp310-cp310-win32.whl", hash = "sha256:1f0e3b4c2ea2cd13238ce43548959c118069db7579e5d40ec270ad77da5833ce"},
-    {file = "tokenizers-0.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:89649c00d0d7211e8186f7a75dfa1db6996f65edce4b84821817eadcc2d3c79e"},
-    {file = "tokenizers-0.13.3-cp311-cp311-macosx_10_11_universal2.whl", hash = "sha256:56b726e0d2bbc9243872b0144515ba684af5b8d8cd112fb83ee1365e26ec74c8"},
-    {file = "tokenizers-0.13.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:cc5c022ce692e1f499d745af293ab9ee6f5d92538ed2faf73f9708c89ee59ce6"},
-    {file = "tokenizers-0.13.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f55c981ac44ba87c93e847c333e58c12abcbb377a0c2f2ef96e1a266e4184ff2"},
-    {file = "tokenizers-0.13.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f247eae99800ef821a91f47c5280e9e9afaeed9980fc444208d5aa6ba69ff148"},
-    {file = "tokenizers-0.13.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b3e3215d048e94f40f1c95802e45dcc37c5b05eb46280fc2ccc8cd351bff839"},
-    {file = "tokenizers-0.13.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ba2b0bf01777c9b9bc94b53764d6684554ce98551fec496f71bc5be3a03e98b"},
-    {file = "tokenizers-0.13.3-cp311-cp311-win32.whl", hash = "sha256:cc78d77f597d1c458bf0ea7c2a64b6aa06941c7a99cb135b5969b0278824d808"},
-    {file = "tokenizers-0.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:ecf182bf59bd541a8876deccf0360f5ae60496fd50b58510048020751cf1724c"},
-    {file = "tokenizers-0.13.3-cp37-cp37m-macosx_10_11_x86_64.whl", hash = "sha256:0527dc5436a1f6bf2c0327da3145687d3bcfbeab91fed8458920093de3901b44"},
-    {file = "tokenizers-0.13.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07cbb2c307627dc99b44b22ef05ff4473aa7c7cc1fec8f0a8b37d8a64b1a16d2"},
-    {file = "tokenizers-0.13.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4560dbdeaae5b7ee0d4e493027e3de6d53c991b5002d7ff95083c99e11dd5ac0"},
-    {file = "tokenizers-0.13.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:64064bd0322405c9374305ab9b4c07152a1474370327499911937fd4a76d004b"},
-    {file = "tokenizers-0.13.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8c6e2ab0f2e3d939ca66aa1d596602105fe33b505cd2854a4c1717f704c51de"},
-    {file = "tokenizers-0.13.3-cp37-cp37m-win32.whl", hash = "sha256:6cc29d410768f960db8677221e497226e545eaaea01aa3613fa0fdf2cc96cff4"},
-    {file = "tokenizers-0.13.3-cp37-cp37m-win_amd64.whl", hash = "sha256:fc2a7fdf864554a0dacf09d32e17c0caa9afe72baf9dd7ddedc61973bae352d8"},
-    {file = "tokenizers-0.13.3-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:8791dedba834c1fc55e5f1521be325ea3dafb381964be20684b92fdac95d79b7"},
-    {file = "tokenizers-0.13.3-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:d607a6a13718aeb20507bdf2b96162ead5145bbbfa26788d6b833f98b31b26e1"},
-    {file = "tokenizers-0.13.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3791338f809cd1bf8e4fee6b540b36822434d0c6c6bc47162448deee3f77d425"},
-    {file = "tokenizers-0.13.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c2f35f30e39e6aab8716f07790f646bdc6e4a853816cc49a95ef2a9016bf9ce6"},
-    {file = "tokenizers-0.13.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:310204dfed5aa797128b65d63538a9837cbdd15da2a29a77d67eefa489edda26"},
-    {file = "tokenizers-0.13.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0f9b92ea052305166559f38498b3b0cae159caea712646648aaa272f7160963"},
-    {file = "tokenizers-0.13.3-cp38-cp38-win32.whl", hash = "sha256:9a3fa134896c3c1f0da6e762d15141fbff30d094067c8f1157b9fdca593b5806"},
-    {file = "tokenizers-0.13.3-cp38-cp38-win_amd64.whl", hash = "sha256:8e7b0cdeace87fa9e760e6a605e0ae8fc14b7d72e9fc19c578116f7287bb873d"},
-    {file = "tokenizers-0.13.3-cp39-cp39-macosx_10_11_x86_64.whl", hash = "sha256:00cee1e0859d55507e693a48fa4aef07060c4bb6bd93d80120e18fea9371c66d"},
-    {file = "tokenizers-0.13.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:a23ff602d0797cea1d0506ce69b27523b07e70f6dda982ab8cf82402de839088"},
-    {file = "tokenizers-0.13.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70ce07445050b537d2696022dafb115307abdffd2a5c106f029490f84501ef97"},
-    {file = "tokenizers-0.13.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:280ffe95f50eaaf655b3a1dc7ff1d9cf4777029dbbc3e63a74e65a056594abc3"},
-    {file = "tokenizers-0.13.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97acfcec592f7e9de8cadcdcda50a7134423ac8455c0166b28c9ff04d227b371"},
-    {file = "tokenizers-0.13.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd7730c98a3010cd4f523465867ff95cd9d6430db46676ce79358f65ae39797b"},
-    {file = "tokenizers-0.13.3-cp39-cp39-win32.whl", hash = "sha256:48625a108029cb1ddf42e17a81b5a3230ba6888a70c9dc14e81bc319e812652d"},
-    {file = "tokenizers-0.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:bc0a6f1ba036e482db6453571c9e3e60ecd5489980ffd95d11dc9f960483d783"},
-    {file = "tokenizers-0.13.3.tar.gz", hash = "sha256:2e546dbb68b623008a5442353137fbb0123d311a6d7ba52f2667c8862a75af2e"},
+    {file = "tokenizers-0.15.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:cd3cd0299aaa312cd2988957598f80becd04d5a07338741eca076057a2b37d6e"},
+    {file = "tokenizers-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8a922c492c721744ee175f15b91704be2d305569d25f0547c77cd6c9f210f9dc"},
+    {file = "tokenizers-0.15.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:331dd786d02fc38698f835fff61c99480f98b73ce75a4c65bd110c9af5e4609a"},
+    {file = "tokenizers-0.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88dd0961c437d413ab027f8b115350c121d49902cfbadf08bb8f634b15fa1814"},
+    {file = "tokenizers-0.15.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6fdcc55339df7761cd52e1fbe8185d3b3963bc9e3f3545faa6c84f9e8818259a"},
+    {file = "tokenizers-0.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1480b0051d8ab5408e8e4db2dc832f7082ea24aa0722c427bde2418c6f3bd07"},
+    {file = "tokenizers-0.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9855e6c258918f9cf62792d4f6ddfa6c56dccd8c8118640f867f6393ecaf8bd7"},
+    {file = "tokenizers-0.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de9529fe75efcd54ba8d516aa725e1851df9199f0669b665c55e90df08f5af86"},
+    {file = "tokenizers-0.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8edcc90a36eab0705fe9121d6c77c6e42eeef25c7399864fd57dfb27173060bf"},
+    {file = "tokenizers-0.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ae17884aafb3e94f34fb7cfedc29054f5f54e142475ebf8a265a4e388fee3f8b"},
+    {file = "tokenizers-0.15.0-cp310-none-win32.whl", hash = "sha256:9a3241acdc9b44cff6e95c4a55b9be943ef3658f8edb3686034d353734adba05"},
+    {file = "tokenizers-0.15.0-cp310-none-win_amd64.whl", hash = "sha256:4b31807cb393d6ea31926b307911c89a1209d5e27629aa79553d1599c8ffdefe"},
+    {file = "tokenizers-0.15.0-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:af7e9be8c05d30bb137b9fd20f9d99354816599e5fd3d58a4b1e28ba3b36171f"},
+    {file = "tokenizers-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3d7343fa562ea29661783344a2d83662db0d3d17a6fa6a403cac8e512d2d9fd"},
+    {file = "tokenizers-0.15.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:32371008788aeeb0309a9244809a23e4c0259625e6b74a103700f6421373f395"},
+    {file = "tokenizers-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca9db64c7c9954fbae698884c5bb089764edc549731e5f9b7fa1dd4e4d78d77f"},
+    {file = "tokenizers-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dbed5944c31195514669cf6381a0d8d47f164943000d10f93d6d02f0d45c25e0"},
+    {file = "tokenizers-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aab16c4a26d351d63e965b0c792f5da7227a37b69a6dc6d922ff70aa595b1b0c"},
+    {file = "tokenizers-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3c2b60b12fdd310bf85ce5d7d3f823456b9b65eed30f5438dd7761879c495983"},
+    {file = "tokenizers-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0344d6602740e44054a9e5bbe9775a5e149c4dddaff15959bb07dcce95a5a859"},
+    {file = "tokenizers-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4525f6997d81d9b6d9140088f4f5131f6627e4c960c2c87d0695ae7304233fc3"},
+    {file = "tokenizers-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:65975094fef8cc68919644936764efd2ce98cf1bacbe8db2687155d2b0625bee"},
+    {file = "tokenizers-0.15.0-cp311-none-win32.whl", hash = "sha256:ff5d2159c5d93015f5a4542aac6c315506df31853123aa39042672031768c301"},
+    {file = "tokenizers-0.15.0-cp311-none-win_amd64.whl", hash = "sha256:2dd681b53cf615e60a31a115a3fda3980e543d25ca183797f797a6c3600788a3"},
+    {file = "tokenizers-0.15.0-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:c9cce6ee149a3d703f86877bc2a6d997e34874b2d5a2d7839e36b2273f31d3d9"},
+    {file = "tokenizers-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a0a94bc3370e6f1cc8a07a8ae867ce13b7c1b4291432a773931a61f256d44ea"},
+    {file = "tokenizers-0.15.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:309cfcccfc7e502cb1f1de2c9c1c94680082a65bfd3a912d5a5b2c90c677eb60"},
+    {file = "tokenizers-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8413e994dd7d875ab13009127fc85633916c71213917daf64962bafd488f15dc"},
+    {file = "tokenizers-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d0ebf9430f901dbdc3dcb06b493ff24a3644c9f88c08e6a1d6d0ae2228b9b818"},
+    {file = "tokenizers-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10361e9c7864b22dd791ec5126327f6c9292fb1d23481d4895780688d5e298ac"},
+    {file = "tokenizers-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:babe42635b8a604c594bdc56d205755f73414fce17ba8479d142a963a6c25cbc"},
+    {file = "tokenizers-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3768829861e964c7a4556f5f23307fce6a23872c2ebf030eb9822dbbbf7e9b2a"},
+    {file = "tokenizers-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9c91588a630adc88065e1c03ac6831e3e2112558869b9ebcb2b8afd8a14c944d"},
+    {file = "tokenizers-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:77606994e793ca54ecf3a3619adc8a906a28ca223d9354b38df41cb8766a0ed6"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:6fe143939f3b596681922b2df12a591a5b010e7dcfbee2202482cd0c1c2f2459"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:b7bee0f1795e3e3561e9a557061b1539e5255b8221e3f928f58100282407e090"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5d37e7f4439b4c46192ab4f2ff38ab815e4420f153caa13dec9272ef14403d34"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caadf255cf7f951b38d10097836d1f3bcff4aeaaffadfdf748bab780bf5bff95"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:05accb9162bf711a941b1460b743d62fec61c160daf25e53c5eea52c74d77814"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26a2ef890740127cb115ee5260878f4a677e36a12831795fd7e85887c53b430b"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e54c5f26df14913620046b33e822cb3bcd091a332a55230c0e63cc77135e2169"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:669b8ed653a578bcff919566631156f5da3aab84c66f3c0b11a6281e8b4731c7"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0ea480d943297df26f06f508dab6e012b07f42bf3dffdd36e70799368a5f5229"},
+    {file = "tokenizers-0.15.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bc80a0a565ebfc7cd89de7dd581da8c2b3238addfca6280572d27d763f135f2f"},
+    {file = "tokenizers-0.15.0-cp37-none-win32.whl", hash = "sha256:cdd945e678bbdf4517d5d8de66578a5030aeefecdb46f5320b034de9cad8d4dd"},
+    {file = "tokenizers-0.15.0-cp37-none-win_amd64.whl", hash = "sha256:1ab96ab7dc706e002c32b2ea211a94c1c04b4f4de48354728c3a6e22401af322"},
+    {file = "tokenizers-0.15.0-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:f21c9eb71c9a671e2a42f18b456a3d118e50c7f0fc4dd9fa8f4eb727fea529bf"},
+    {file = "tokenizers-0.15.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2a5f4543a35889679fc3052086e69e81880b2a5a28ff2a52c5a604be94b77a3f"},
+    {file = "tokenizers-0.15.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f8aa81afec893e952bd39692b2d9ef60575ed8c86fce1fd876a06d2e73e82dca"},
+    {file = "tokenizers-0.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1574a5a4af22c3def93fe8fe4adcc90a39bf5797ed01686a4c46d1c3bc677d2f"},
+    {file = "tokenizers-0.15.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7c7982fd0ec9e9122d03b209dac48cebfea3de0479335100ef379a9a959b9a5a"},
+    {file = "tokenizers-0.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d16b647032df2ce2c1f9097236e046ea9fedd969b25637b9d5d734d78aa53b"},
+    {file = "tokenizers-0.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b3cdf29e6f9653da330515dc8fa414be5a93aae79e57f8acc50d4028dd843edf"},
+    {file = "tokenizers-0.15.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7286f3df10de840867372e3e64b99ef58c677210e3ceb653cd0e740a5c53fe78"},
+    {file = "tokenizers-0.15.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aabc83028baa5a36ce7a94e7659250f0309c47fa4a639e5c2c38e6d5ea0de564"},
+    {file = "tokenizers-0.15.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:72f78b0e0e276b1fc14a672fa73f3acca034ba8db4e782124a2996734a9ba9cf"},
+    {file = "tokenizers-0.15.0-cp38-none-win32.whl", hash = "sha256:9680b0ecc26e7e42f16680c1aa62e924d58d1c2dd992707081cc10a374896ea2"},
+    {file = "tokenizers-0.15.0-cp38-none-win_amd64.whl", hash = "sha256:f17cbd88dab695911cbdd385a5a7e3709cc61dff982351f5d1b5939f074a2466"},
+    {file = "tokenizers-0.15.0-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:3661862df7382c5eb23ac4fbf7c75e69b02dc4f5784e4c5a734db406b5b24596"},
+    {file = "tokenizers-0.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3045d191dad49647f5a5039738ecf1c77087945c7a295f7bcf051c37067e883"},
+    {file = "tokenizers-0.15.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9fcaad9ab0801f14457d7c820d9f246b5ab590c407fc6b073819b1573097aa7"},
+    {file = "tokenizers-0.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a79f17027f24fe9485701c8dbb269b9c713954ec3bdc1e7075a66086c0c0cd3c"},
+    {file = "tokenizers-0.15.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01a3aa332abc4bee7640563949fcfedca4de8f52691b3b70f2fc6ca71bfc0f4e"},
+    {file = "tokenizers-0.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05b83896a893cdfedad8785250daa3ba9f0504848323471524d4783d7291661e"},
+    {file = "tokenizers-0.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbbf2489fcf25d809731ba2744ff278dd07d9eb3f8b7482726bd6cae607073a4"},
+    {file = "tokenizers-0.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab806ad521a5e9de38078b7add97589c313915f6f5fec6b2f9f289d14d607bd6"},
+    {file = "tokenizers-0.15.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4a522612d5c88a41563e3463226af64e2fa00629f65cdcc501d1995dd25d23f5"},
+    {file = "tokenizers-0.15.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e58a38c4e6075810bdfb861d9c005236a72a152ebc7005941cc90d1bbf16aca9"},
+    {file = "tokenizers-0.15.0-cp39-none-win32.whl", hash = "sha256:b8034f1041fd2bd2b84ff9f4dc4ae2e1c3b71606820a9cd5c562ebd291a396d1"},
+    {file = "tokenizers-0.15.0-cp39-none-win_amd64.whl", hash = "sha256:edde9aa964145d528d0e0dbf14f244b8a85ebf276fb76869bc02e2530fa37a96"},
+    {file = "tokenizers-0.15.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:309445d10d442b7521b98083dc9f0b5df14eca69dbbfebeb98d781ee2cef5d30"},
+    {file = "tokenizers-0.15.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d3125a6499226d4d48efc54f7498886b94c418e93a205b673bc59364eecf0804"},
+    {file = "tokenizers-0.15.0-pp310-pypy310_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ed56ddf0d54877bb9c6d885177db79b41576e61b5ef6defeb579dcb803c04ad5"},
+    {file = "tokenizers-0.15.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b22cd714706cc5b18992a232b023f736e539495f5cc61d2d28d176e55046f6c"},
+    {file = "tokenizers-0.15.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fac2719b1e9bc8e8e7f6599b99d0a8e24f33d023eb8ef644c0366a596f0aa926"},
+    {file = "tokenizers-0.15.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:85ddae17570ec7e5bfaf51ffa78d044f444a8693e1316e1087ee6150596897ee"},
+    {file = "tokenizers-0.15.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:76f1bed992e396bf6f83e3df97b64ff47885e45e8365f8983afed8556a0bc51f"},
+    {file = "tokenizers-0.15.0-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:3bb0f4df6dce41a1c7482087b60d18c372ef4463cb99aa8195100fcd41e0fd64"},
+    {file = "tokenizers-0.15.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:22c27672c27a059a5f39ff4e49feed8c7f2e1525577c8a7e3978bd428eb5869d"},
+    {file = "tokenizers-0.15.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78104f5d035c9991f92831fc0efe9e64a05d4032194f2a69f67aaa05a4d75bbb"},
+    {file = "tokenizers-0.15.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a40b73dc19d82c3e3ffb40abdaacca8fbc95eeb26c66b7f9f860aebc07a73998"},
+    {file = "tokenizers-0.15.0-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d801d1368188c74552cd779b1286e67cb9fd96f4c57a9f9a2a09b6def9e1ab37"},
+    {file = "tokenizers-0.15.0-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82641ffb13a4da1293fcc9f437d457647e60ed0385a9216cd135953778b3f0a1"},
+    {file = "tokenizers-0.15.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:160f9d1810f2c18fffa94aa98bf17632f6bd2dabc67fcb01a698ca80c37d52ee"},
+    {file = "tokenizers-0.15.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:8d7d6eea831ed435fdeeb9bcd26476226401d7309d115a710c65da4088841948"},
+    {file = "tokenizers-0.15.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f6456bec6c557d63d8ec0023758c32f589e1889ed03c055702e84ce275488bed"},
+    {file = "tokenizers-0.15.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1eef39a502fad3bf104b9e1906b4fb0cee20e44e755e51df9a98f8922c3bf6d4"},
+    {file = "tokenizers-0.15.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1e4664c5b797e093c19b794bbecc19d2367e782b4a577d8b7c1821db5dc150d"},
+    {file = "tokenizers-0.15.0-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:ca003fb5f3995ff5cf676db6681b8ea5d54d3b30bea36af1120e78ee1a4a4cdf"},
+    {file = "tokenizers-0.15.0-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:7f17363141eb0c53752c89e10650b85ef059a52765d0802ba9613dbd2d21d425"},
+    {file = "tokenizers-0.15.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:8a765db05581c7d7e1280170f2888cda351760d196cc059c37ea96f121125799"},
+    {file = "tokenizers-0.15.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:2a0dd641a72604486cd7302dd8f87a12c8a9b45e1755e47d2682733f097c1af5"},
+    {file = "tokenizers-0.15.0-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a1a3c973e4dc97797fc19e9f11546c95278ffc55c4492acb742f69e035490bc"},
+    {file = "tokenizers-0.15.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4fab75642aae4e604e729d6f78e0addb9d7e7d49e28c8f4d16b24da278e5263"},
+    {file = "tokenizers-0.15.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65f80be77f6327a86d8fd35a4467adcfe6174c159b4ab52a1a8dd4c6f2d7d9e1"},
+    {file = "tokenizers-0.15.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a8da7533dbe66b88afd430c56a2f2ce1fd82e2681868f857da38eeb3191d7498"},
+    {file = "tokenizers-0.15.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fa8eb4584fc6cbe6a84d7a7864be3ed28e23e9fd2146aa8ef1814d579df91958"},
+    {file = "tokenizers-0.15.0.tar.gz", hash = "sha256:10c7e6e7b4cabd757da59e93f5f8d1126291d16f8b54f28510825ef56a3e5d0e"},
 ]
 
+[package.dependencies]
+huggingface_hub = ">=0.16.4,<1.0"
+
 [package.extras]
-dev = ["black (==22.3)", "datasets", "numpy", "pytest", "requests"]
-docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
+dev = ["tokenizers[testing]"]
+docs = ["setuptools_rust", "sphinx", "sphinx_rtd_theme"]
 testing = ["black (==22.3)", "datasets", "numpy", "pytest", "requests"]
+
+[[package]]
+name = "tomlkit"
+version = "0.12.0"
+description = "Style preserving TOML library"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "tomlkit-0.12.0-py3-none-any.whl", hash = "sha256:926f1f37a1587c7a4f6c7484dae538f1345d96d793d9adab5d3675957b1d0766"},
+    {file = "tomlkit-0.12.0.tar.gz", hash = "sha256:01f0477981119c7d8ee0f67ebe0297a7c95b14cf9f4b102b45486deb77018716"},
+]
 
 [[package]]
 name = "toolz"
@@ -4373,38 +4507,6 @@ typing-extensions = "*"
 
 [package.extras]
 opt-einsum = ["opt-einsum (>=3.3)"]
-
-[[package]]
-name = "torch"
-version = "2.0.1+cpu"
-description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "torch-2.0.1+cpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:fec257249ba014c68629a1994b0c6e7356e20e1afc77a87b9941a40e5095285d"},
-    {file = "torch-2.0.1+cpu-cp310-cp310-win_amd64.whl", hash = "sha256:ca88b499973c4c027e32c4960bf20911d7e984bd0c55cda181dc643559f3d93f"},
-    {file = "torch-2.0.1+cpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:274d4acf486ef50ce1066ffe9d500beabb32bde69db93e3b71d0892dd148956c"},
-    {file = "torch-2.0.1+cpu-cp311-cp311-win_amd64.whl", hash = "sha256:e2603310bdff4b099c4c41ae132192fc0d6b00932ae2621d52d87218291864be"},
-    {file = "torch-2.0.1+cpu-cp38-cp38-linux_x86_64.whl", hash = "sha256:8046f49deae5a3d219b9f6059a1f478ae321f232e660249355a8bf6dcaa810c1"},
-    {file = "torch-2.0.1+cpu-cp38-cp38-win_amd64.whl", hash = "sha256:2ac4382ff090035f9045b18afe5763e2865dd35f2d661c02e51f658d95c8065a"},
-    {file = "torch-2.0.1+cpu-cp39-cp39-linux_x86_64.whl", hash = "sha256:73482a223d577407c45685fde9d2a74ba42f0d8d9f6e1e95c08071dc55c47d7b"},
-    {file = "torch-2.0.1+cpu-cp39-cp39-win_amd64.whl", hash = "sha256:f263f8e908288427ae81441fef540377f61e339a27632b1bbe33cf78292fdaea"},
-]
-
-[package.dependencies]
-filelock = "*"
-jinja2 = "*"
-networkx = "*"
-sympy = "*"
-typing-extensions = "*"
-
-[package.extras]
-opt-einsum = ["opt-einsum (>=3.3)"]
-
-[package.source]
-type = "legacy"
-url = "https://download.pytorch.org/whl/cpu"
-reference = "torchcpu"
 
 [[package]]
 name = "torchvision"
@@ -4501,53 +4603,52 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.5.1)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "transformers"
-version = "4.33.2"
+version = "4.36.2"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "transformers-4.33.2-py3-none-any.whl", hash = "sha256:5a9a757bea5b5a1b94796805bcb5978b552208a3ac193f46edda66be6f4a5488"},
-    {file = "transformers-4.33.2.tar.gz", hash = "sha256:47dd36f302afec86d9cdcacab61bbd0296e6bb02e64d2ed7855daaab14ee290e"},
+    {file = "transformers-4.36.2-py3-none-any.whl", hash = "sha256:462066c4f74ee52516f12890dcc9ec71d1a5e97998db621668455117a54330f6"},
+    {file = "transformers-4.36.2.tar.gz", hash = "sha256:d8068e897e47793281501e547d2bbdfc5b8556409c2cb6c3d9e2ca77d4c0b4ec"},
 ]
 
 [package.dependencies]
 filelock = "*"
-huggingface-hub = ">=0.15.1,<1.0"
+huggingface-hub = ">=0.19.3,<1.0"
 numpy = ">=1.17"
 packaging = ">=20.0"
 pyyaml = ">=5.1"
 regex = "!=2019.12.17"
 requests = "*"
 safetensors = ">=0.3.1"
-tokenizers = ">=0.11.1,<0.11.3 || >0.11.3,<0.14"
+tokenizers = ">=0.14,<0.19"
 tqdm = ">=4.27"
 
 [package.extras]
-accelerate = ["accelerate (>=0.20.3)"]
-agents = ["Pillow (<10.0.0)", "accelerate (>=0.20.3)", "datasets (!=2.5.0)", "diffusers", "opencv-python", "sentencepiece (>=0.1.91,!=0.1.92)", "torch (>=1.10,!=1.12.0)"]
-all = ["Pillow (<10.0.0)", "accelerate (>=0.20.3)", "av (==9.2.0)", "codecarbon (==1.2.0)", "decord (==0.6.0)", "flax (>=0.4.1,<=0.7.0)", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "onnxconverter-common", "optax (>=0.0.8,<=0.1.4)", "optuna", "phonemizer", "protobuf", "pyctcdecode (>=0.4.0)", "ray[tune]", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "tensorflow (>=2.6,<2.15)", "tensorflow-text (<2.15)", "tf2onnx", "timm", "tokenizers (>=0.11.1,!=0.11.3,<0.14)", "torch (>=1.10,!=1.12.0)", "torchaudio", "torchvision"]
+accelerate = ["accelerate (>=0.21.0)"]
+agents = ["Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "datasets (!=2.5.0)", "diffusers", "opencv-python", "sentencepiece (>=0.1.91,!=0.1.92)", "torch (>=1.10,!=1.12.0)"]
+all = ["Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "av (==9.2.0)", "codecarbon (==1.2.0)", "decord (==0.6.0)", "flax (>=0.4.1,<=0.7.0)", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "onnxconverter-common", "optax (>=0.0.8,<=0.1.4)", "optuna", "phonemizer", "protobuf", "pyctcdecode (>=0.4.0)", "ray[tune] (>=2.7.0)", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "tensorflow (>=2.6,<2.16)", "tensorflow-text (<2.16)", "tf2onnx", "timm", "tokenizers (>=0.14,<0.19)", "torch (>=1.10,!=1.12.0)", "torchaudio", "torchvision"]
 audio = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)"]
 codecarbon = ["codecarbon (==1.2.0)"]
-deepspeed = ["accelerate (>=0.20.3)", "deepspeed (>=0.9.3)"]
-deepspeed-testing = ["GitPython (<3.1.19)", "accelerate (>=0.20.3)", "beautifulsoup4", "black (>=23.1,<24.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "deepspeed (>=0.9.3)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "hf-doc-builder (>=0.3.0)", "nltk", "optuna", "parameterized", "protobuf", "psutil", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "sentencepiece (>=0.1.91,!=0.1.92)", "timeout-decorator"]
-dev = ["GitPython (<3.1.19)", "Pillow (<10.0.0)", "accelerate (>=0.20.3)", "av (==9.2.0)", "beautifulsoup4", "black (>=23.1,<24.0)", "codecarbon (==1.2.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "decord (==0.6.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "flax (>=0.4.1,<=0.7.0)", "fugashi (>=1.0)", "hf-doc-builder", "hf-doc-builder (>=0.3.0)", "ipadic (>=1.0.0,<2.0)", "isort (>=5.5.4)", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "nltk", "onnxconverter-common", "optax (>=0.0.8,<=0.1.4)", "optuna", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "ray[tune]", "rhoknp (>=1.1.0,<1.3.1)", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (>=0.0.241,<=0.0.259)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "sudachidict-core (>=20220729)", "sudachipy (>=0.6.6)", "tensorflow (>=2.6,<2.15)", "tensorflow-text (<2.15)", "tf2onnx", "timeout-decorator", "timm", "tokenizers (>=0.11.1,!=0.11.3,<0.14)", "torch (>=1.10,!=1.12.0)", "torchaudio", "torchvision", "unidic (>=1.0.2)", "unidic-lite (>=1.0.7)", "urllib3 (<2.0.0)"]
-dev-tensorflow = ["GitPython (<3.1.19)", "Pillow (<10.0.0)", "beautifulsoup4", "black (>=23.1,<24.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "hf-doc-builder", "hf-doc-builder (>=0.3.0)", "isort (>=5.5.4)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "nltk", "onnxconverter-common", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (>=0.0.241,<=0.0.259)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "sentencepiece (>=0.1.91,!=0.1.92)", "tensorflow (>=2.6,<2.15)", "tensorflow-text (<2.15)", "tf2onnx", "timeout-decorator", "tokenizers (>=0.11.1,!=0.11.3,<0.14)", "urllib3 (<2.0.0)"]
-dev-torch = ["GitPython (<3.1.19)", "Pillow (<10.0.0)", "accelerate (>=0.20.3)", "beautifulsoup4", "black (>=23.1,<24.0)", "codecarbon (==1.2.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "fugashi (>=1.0)", "hf-doc-builder", "hf-doc-builder (>=0.3.0)", "ipadic (>=1.0.0,<2.0)", "isort (>=5.5.4)", "kenlm", "librosa", "nltk", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "optuna", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "ray[tune]", "rhoknp (>=1.1.0,<1.3.1)", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (>=0.0.241,<=0.0.259)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "sudachidict-core (>=20220729)", "sudachipy (>=0.6.6)", "timeout-decorator", "timm", "tokenizers (>=0.11.1,!=0.11.3,<0.14)", "torch (>=1.10,!=1.12.0)", "torchaudio", "torchvision", "unidic (>=1.0.2)", "unidic-lite (>=1.0.7)", "urllib3 (<2.0.0)"]
-docs = ["Pillow (<10.0.0)", "accelerate (>=0.20.3)", "av (==9.2.0)", "codecarbon (==1.2.0)", "decord (==0.6.0)", "flax (>=0.4.1,<=0.7.0)", "hf-doc-builder", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "onnxconverter-common", "optax (>=0.0.8,<=0.1.4)", "optuna", "phonemizer", "protobuf", "pyctcdecode (>=0.4.0)", "ray[tune]", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "tensorflow (>=2.6,<2.15)", "tensorflow-text (<2.15)", "tf2onnx", "timm", "tokenizers (>=0.11.1,!=0.11.3,<0.14)", "torch (>=1.10,!=1.12.0)", "torchaudio", "torchvision"]
+deepspeed = ["accelerate (>=0.21.0)", "deepspeed (>=0.9.3)"]
+deepspeed-testing = ["GitPython (<3.1.19)", "accelerate (>=0.21.0)", "beautifulsoup4", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "deepspeed (>=0.9.3)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "hf-doc-builder (>=0.3.0)", "nltk", "optuna", "parameterized", "protobuf", "psutil", "pydantic (<2)", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.1.5)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "sentencepiece (>=0.1.91,!=0.1.92)", "tensorboard", "timeout-decorator"]
+dev = ["GitPython (<3.1.19)", "Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "av (==9.2.0)", "beautifulsoup4", "codecarbon (==1.2.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "decord (==0.6.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "flax (>=0.4.1,<=0.7.0)", "fugashi (>=1.0)", "hf-doc-builder", "hf-doc-builder (>=0.3.0)", "ipadic (>=1.0.0,<2.0)", "isort (>=5.5.4)", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "nltk", "onnxconverter-common", "optax (>=0.0.8,<=0.1.4)", "optuna", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pydantic (<2)", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "ray[tune] (>=2.7.0)", "rhoknp (>=1.1.0,<1.3.1)", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.1.5)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "sudachidict-core (>=20220729)", "sudachipy (>=0.6.6)", "tensorboard", "tensorflow (>=2.6,<2.16)", "tensorflow-text (<2.16)", "tf2onnx", "timeout-decorator", "timm", "tokenizers (>=0.14,<0.19)", "torch (>=1.10,!=1.12.0)", "torchaudio", "torchvision", "unidic (>=1.0.2)", "unidic-lite (>=1.0.7)", "urllib3 (<2.0.0)"]
+dev-tensorflow = ["GitPython (<3.1.19)", "Pillow (>=10.0.1,<=15.0)", "beautifulsoup4", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "hf-doc-builder", "hf-doc-builder (>=0.3.0)", "isort (>=5.5.4)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "nltk", "onnxconverter-common", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pydantic (<2)", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.1.5)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "sentencepiece (>=0.1.91,!=0.1.92)", "tensorboard", "tensorflow (>=2.6,<2.16)", "tensorflow-text (<2.16)", "tf2onnx", "timeout-decorator", "tokenizers (>=0.14,<0.19)", "urllib3 (<2.0.0)"]
+dev-torch = ["GitPython (<3.1.19)", "Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "beautifulsoup4", "codecarbon (==1.2.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "fugashi (>=1.0)", "hf-doc-builder", "hf-doc-builder (>=0.3.0)", "ipadic (>=1.0.0,<2.0)", "isort (>=5.5.4)", "kenlm", "librosa", "nltk", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "optuna", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pydantic (<2)", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "ray[tune] (>=2.7.0)", "rhoknp (>=1.1.0,<1.3.1)", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.1.5)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "sudachidict-core (>=20220729)", "sudachipy (>=0.6.6)", "tensorboard", "timeout-decorator", "timm", "tokenizers (>=0.14,<0.19)", "torch (>=1.10,!=1.12.0)", "torchaudio", "torchvision", "unidic (>=1.0.2)", "unidic-lite (>=1.0.7)", "urllib3 (<2.0.0)"]
+docs = ["Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "av (==9.2.0)", "codecarbon (==1.2.0)", "decord (==0.6.0)", "flax (>=0.4.1,<=0.7.0)", "hf-doc-builder", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "onnxconverter-common", "optax (>=0.0.8,<=0.1.4)", "optuna", "phonemizer", "protobuf", "pyctcdecode (>=0.4.0)", "ray[tune] (>=2.7.0)", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "tensorflow (>=2.6,<2.16)", "tensorflow-text (<2.16)", "tf2onnx", "timm", "tokenizers (>=0.14,<0.19)", "torch (>=1.10,!=1.12.0)", "torchaudio", "torchvision"]
 docs-specific = ["hf-doc-builder"]
-fairscale = ["fairscale (>0.3)"]
 flax = ["flax (>=0.4.1,<=0.7.0)", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "optax (>=0.0.8,<=0.1.4)"]
 flax-speech = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)"]
 ftfy = ["ftfy"]
-integrations = ["optuna", "ray[tune]", "sigopt"]
+integrations = ["optuna", "ray[tune] (>=2.7.0)", "sigopt"]
 ja = ["fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "rhoknp (>=1.1.0,<1.3.1)", "sudachidict-core (>=20220729)", "sudachipy (>=0.6.6)", "unidic (>=1.0.2)", "unidic-lite (>=1.0.7)"]
 modelcreation = ["cookiecutter (==1.7.3)"]
 natten = ["natten (>=0.14.6)"]
 onnx = ["onnxconverter-common", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "tf2onnx"]
 onnxruntime = ["onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)"]
 optuna = ["optuna"]
-quality = ["GitPython (<3.1.19)", "black (>=23.1,<24.0)", "datasets (!=2.5.0)", "hf-doc-builder (>=0.3.0)", "isort (>=5.5.4)", "ruff (>=0.0.241,<=0.0.259)", "urllib3 (<2.0.0)"]
-ray = ["ray[tune]"]
+quality = ["GitPython (<3.1.19)", "datasets (!=2.5.0)", "hf-doc-builder (>=0.3.0)", "isort (>=5.5.4)", "ruff (==0.1.5)", "urllib3 (<2.0.0)"]
+ray = ["ray[tune] (>=2.7.0)"]
 retrieval = ["datasets (!=2.5.0)", "faiss-cpu"]
 sagemaker = ["sagemaker (>=2.31.0)"]
 sentencepiece = ["protobuf", "sentencepiece (>=0.1.91,!=0.1.92)"]
@@ -4555,18 +4656,42 @@ serving = ["fastapi", "pydantic (<2)", "starlette", "uvicorn"]
 sigopt = ["sigopt"]
 sklearn = ["scikit-learn"]
 speech = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)", "torchaudio"]
-testing = ["GitPython (<3.1.19)", "beautifulsoup4", "black (>=23.1,<24.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "hf-doc-builder (>=0.3.0)", "nltk", "parameterized", "protobuf", "psutil", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "timeout-decorator"]
-tf = ["keras-nlp (>=0.3.1)", "onnxconverter-common", "tensorflow (>=2.6,<2.15)", "tensorflow-text (<2.15)", "tf2onnx"]
-tf-cpu = ["keras-nlp (>=0.3.1)", "onnxconverter-common", "tensorflow-cpu (>=2.6,<2.15)", "tensorflow-text (<2.15)", "tf2onnx"]
+testing = ["GitPython (<3.1.19)", "beautifulsoup4", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "hf-doc-builder (>=0.3.0)", "nltk", "parameterized", "protobuf", "psutil", "pydantic (<2)", "pytest (>=7.2.0)", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.1.5)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "tensorboard", "timeout-decorator"]
+tf = ["keras-nlp (>=0.3.1)", "onnxconverter-common", "tensorflow (>=2.6,<2.16)", "tensorflow-text (<2.16)", "tf2onnx"]
+tf-cpu = ["keras-nlp (>=0.3.1)", "onnxconverter-common", "tensorflow-cpu (>=2.6,<2.16)", "tensorflow-text (<2.16)", "tf2onnx"]
 tf-speech = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)"]
 timm = ["timm"]
-tokenizers = ["tokenizers (>=0.11.1,!=0.11.3,<0.14)"]
-torch = ["accelerate (>=0.20.3)", "torch (>=1.10,!=1.12.0)"]
+tokenizers = ["tokenizers (>=0.14,<0.19)"]
+torch = ["accelerate (>=0.21.0)", "torch (>=1.10,!=1.12.0)"]
 torch-speech = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)", "torchaudio"]
-torch-vision = ["Pillow (<10.0.0)", "torchvision"]
-torchhub = ["filelock", "huggingface-hub (>=0.15.1,<1.0)", "importlib-metadata", "numpy (>=1.17)", "packaging (>=20.0)", "protobuf", "regex (!=2019.12.17)", "requests", "sentencepiece (>=0.1.91,!=0.1.92)", "tokenizers (>=0.11.1,!=0.11.3,<0.14)", "torch (>=1.10,!=1.12.0)", "tqdm (>=4.27)"]
+torch-vision = ["Pillow (>=10.0.1,<=15.0)", "torchvision"]
+torchhub = ["filelock", "huggingface-hub (>=0.19.3,<1.0)", "importlib-metadata", "numpy (>=1.17)", "packaging (>=20.0)", "protobuf", "regex (!=2019.12.17)", "requests", "sentencepiece (>=0.1.91,!=0.1.92)", "tokenizers (>=0.14,<0.19)", "torch (>=1.10,!=1.12.0)", "tqdm (>=4.27)"]
 video = ["av (==9.2.0)", "decord (==0.6.0)"]
-vision = ["Pillow (<10.0.0)"]
+vision = ["Pillow (>=10.0.1,<=15.0)"]
+
+[[package]]
+name = "typer"
+version = "0.9.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "typer-0.9.0-py3-none-any.whl", hash = "sha256:5d96d986a21493606a358cae4461bd8cdf83cbf33a5aa950ae629ca3b51467ee"},
+    {file = "typer-0.9.0.tar.gz", hash = "sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2"},
+]
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+colorama = {version = ">=0.4.3,<0.5.0", optional = true, markers = "extra == \"all\""}
+rich = {version = ">=10.11.0,<14.0.0", optional = true, markers = "extra == \"all\""}
+shellingham = {version = ">=1.3.0,<2.0.0", optional = true, markers = "extra == \"all\""}
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
 name = "typing-extensions"
@@ -5029,9 +5154,9 @@ multidict = ">=4.0"
 api-bot = ["fastapi", "pydantic", "requests", "uvicorn"]
 azure = ["pulumi", "pulumi-azure-native"]
 ft-notebooks = ["datasets", "faiss-cpu", "ipykernel"]
-llama-index-notebooks = ["bitsandbytes", "gradio", "httpx", "ipykernel", "nbconvert"]
+llama-index-notebooks = ["bitsandbytes", "gradio", "ipykernel", "nbconvert"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "600637acf96d7886432c8fef9a73e07db9c55ddab3dfe03e046f77e92728faf2"
+content-hash = "af98ffbca50c5256df5a8f92440734f00f0fc7b88a2606dccb021166a13d3952"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,26 +23,26 @@ datasets = { version="^2.12.0", optional=true }
 faiss-cpu = { version="^1.7.4", optional=true }
 fastapi = { version="^0.103.1", optional=true }
 gitpython = "^3.1.36"
-gradio = { version="^3.34.0", optional=true }
+gradio = { version = "^4.12.0", optional=true }
 httpx = "^0.25.0"
 ipykernel = { version="^6.23.2", optional=true }
 langchain = "^0.0.329"
 llama-cpp-python = "^0.2.11"
 llama-index = "^0.8.57"
 llama-hub = "^0.0.42"
-nbconvert = {version = "^7.8.0", optional = true}
+nbconvert = { version = "^7.8.0", optional = true }
 nest_asyncio = "^1.5.8"
 openai = "^0.27.8"
 pandas = "^2.0.2"
 pulumi = { version="^3.70.0", optional=true }
 pulumi-azure-native = { version="^1.103.0", optional=true }
-pydantic = {version = "^2.4.1", optional=true }
-requests = {version = "^2.31.0", optional=true }
+pydantic = { version = "^2.4.1", optional=true }
+requests = { version = "^2.31.0", optional=true }
 safetensors = "^0.3.3"
 slack-sdk = "^3.21.3"
 sentence-transformers = "^2.2.2"
 torch = "^2.0.1"
-transformers = "^4.33.2"
+transformers = "^4.36.2"
 uvicorn = { version="^0.23.2", optional=true }
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ faiss-cpu = { version="^1.7.4", optional=true }
 fastapi = { version="^0.103.1", optional=true }
 gitpython = "^3.1.36"
 gradio = { version = "^4.12.0", optional=true }
-httpx = "^0.25.0"
+httpx = "^0.26.0"
 ipykernel = { version="^6.23.2", optional=true }
 langchain = "^0.0.329"
 llama-cpp-python = "^0.2.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ llama_index_notebooks = [
 reginald_run = "reginald.run:cli"
 reginald_run_api_bot = "reginald.slack_bot.setup_bot:cli"
 reginald_run_api_llm = "reginald.models.app:main"
+reginald_create_index = "reginald.models.create_index:main"
 
 [[tool.poetry.source]]
 name = "PyPI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ faiss-cpu = { version="^1.7.4", optional=true }
 fastapi = { version="^0.103.1", optional=true }
 gitpython = "^3.1.36"
 gradio = { version="^3.34.0", optional=true }
-httpx = { version="^0.25.0", optional=true }
+httpx = "^0.25.0"
 ipykernel = { version="^6.23.2", optional=true }
 langchain = "^0.0.329"
 llama-cpp-python = "^0.2.11"
@@ -41,10 +41,7 @@ requests = {version = "^2.31.0", optional=true }
 safetensors = "^0.3.3"
 slack-sdk = "^3.21.3"
 sentence-transformers = "^2.2.2"
-torch = [
-  { version = "^2.0.1", markers = "sys_platform != 'linux'", source = "PyPI" },
-  { version = "^2.0.1+cpu", markers = "sys_platform == 'linux'", source = "torchcpu" }
-]
+torch = "^2.0.1"
 transformers = "^4.33.2"
 uvicorn = { version="^0.23.2", optional=true }
 
@@ -73,8 +70,7 @@ llama_index_notebooks = [
     "bitsandbytes",
     "gradio",
     "ipykernel",
-    "nbconvert",
-    "httpx"
+    "nbconvert"
 ]
 
 [tool.poetry.scripts]
@@ -86,11 +82,6 @@ reginald_create_index = "reginald.models.create_index:main"
 [[tool.poetry.source]]
 name = "PyPI"
 priority = "primary"
-
-[[tool.poetry.source]]
-name = "torchcpu"
-url = "https://download.pytorch.org/whl/cpu/"
-priority = "explicit"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ gitpython = "^3.1.36"
 gradio = { version = "^4.12.0", optional=true }
 httpx = "^0.25.0"
 ipykernel = { version="^6.23.2", optional=true }
-langchain = "^0.0.353"
+langchain = "^0.0.329"
 llama-cpp-python = "^0.2.11"
 llama-index = "^0.8.62"
 llama-hub = "^0.0.42"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,18 +17,18 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
-accelerate = "^0.23.0"
+accelerate = "^0.25.0"
 bitsandbytes = { version="^0.41.1", optional=true }
-datasets = { version="^2.12.0", optional=true }
+datasets = { version="^2.16.1", optional=true }
 faiss-cpu = { version="^1.7.4", optional=true }
 fastapi = { version="^0.103.1", optional=true }
 gitpython = "^3.1.36"
 gradio = { version = "^4.12.0", optional=true }
 httpx = "^0.25.0"
 ipykernel = { version="^6.23.2", optional=true }
-langchain = "^0.0.329"
+langchain = "^0.0.353"
 llama-cpp-python = "^0.2.11"
-llama-index = "^0.8.57"
+llama-index = "^0.8.62"
 llama-hub = "^0.0.42"
 nbconvert = { version = "^7.8.0", optional = true }
 nest_asyncio = "^1.5.8"

--- a/reginald/models/app.py
+++ b/reginald/models/app.py
@@ -1,12 +1,11 @@
 import logging
-import os
 
 import uvicorn
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 from reginald.models.setup_llm import setup_llm
-from reginald.utils import Parser
+from reginald.parser_utils import Parser, get_args
 
 
 class Query(BaseModel):
@@ -27,7 +26,7 @@ def main():
     parser = Parser()
 
     # pass args to setup_llm
-    llm_kwargs = vars(parser.parse_args())
+    args = get_args(parser)
 
     # initialise logging
     logging.basicConfig(
@@ -37,7 +36,7 @@ def main():
     )
 
     # set up response model
-    response_model = setup_llm(**llm_kwargs)
+    response_model = setup_llm(**vars(args))
 
     # set up FastAPI
     app = FastAPI()

--- a/reginald/models/create_index.py
+++ b/reginald/models/create_index.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 from typing import Any
 
 from llama_index.llms import (
@@ -69,19 +70,16 @@ def main():
         llm=DummyLLM(),
         max_input_size=args.max_input_size or DEFAULT_ARGS["max_input_size"],
         num_output=args.num_output or DEFAULT_ARGS["num_output"],
-        chunk_size=args.chunk_size
-        or int(
-            (args.max_input_size or DEFAULT_ARGS["max_input_size"])
-            / ((args.k or DEFAULT_ARGS["k"]) + 1)
-        ),
         chunk_overlap_ratio=args.chunk_overlap_ratio
         or DEFAULT_ARGS["chunk_overlap_ratio"],
+        chunk_size=args.chunk_size,
+        k=args.k or DEFAULT_ARGS["k"],
     )
 
     # set up slack bot
     logging.info("Generating the index from scratch...")
     data_creator = DataIndexCreator(
-        data_dir=args.data_dir or DEFAULT_ARGS["data_dir"],
+        data_dir=pathlib.Path(args.data_dir or DEFAULT_ARGS["data_dir"]).resolve(),
         which_index=args.which_index or DEFAULT_ARGS["which_index"],
         service_context=service_context,
     )

--- a/reginald/models/create_index.py
+++ b/reginald/models/create_index.py
@@ -1,0 +1,52 @@
+import logging
+
+from reginald.models.models.llama_index import DataIndexCreator, setup_service_context
+from reginald.models.setup_llm import DEFAULT_ARGS
+from reginald.parser_utils import Parser, get_args
+
+
+def main():
+    """
+    Main function to create the indices for the LlamaIndex models.
+    """
+    # initialise logging
+    logging.basicConfig(
+        datefmt=r"%Y-%m-%d %H:%M:%S",
+        format="%(asctime)s [%(levelname)8s] %(message)s",
+        level=logging.INFO,
+    )
+
+    # parse command line arguments
+    parser = Parser(create_index_only=True)
+
+    # pass args to setup_llm
+    args = get_args(parser)
+
+    # pass args to create data index
+    logging.info("Setting up service context...")
+    service_context = setup_service_context(
+        llm="default",
+        max_input_size=args.max_input_size or DEFAULT_ARGS["max_input_size"],
+        num_output=args.num_output or DEFAULT_ARGS["num_output"],
+        chunk_size=args.chunk_size
+        or int(
+            (args.max_input_size or DEFAULT_ARGS["max_input_size"])
+            / ((args.k or DEFAULT_ARGS["k"]) + 1)
+        ),
+        chunk_overlap_ratio=args.chunk_overlap_ratio
+        or DEFAULT_ARGS["chunk_overlap_ratio"],
+    )
+
+    # set up slack bot
+    logging.info("Generating the index from scratch...")
+    data_creator = DataIndexCreator(
+        data_dir=args.data_dir or DEFAULT_ARGS["data_dir"],
+        which_index=args.which_index or DEFAULT_ARGS["which_index"],
+        service_context=service_context,
+    )
+    data_creator.create_index()
+    data_creator.save_index()
+
+
+if __name__ == "__main__":
+    main()

--- a/reginald/models/models/chat_completion.py
+++ b/reginald/models/models/chat_completion.py
@@ -5,6 +5,7 @@ from typing import Any
 import openai
 
 from reginald.models.models.base import MessageResponse, ResponseModel
+from reginald.utils import get_env_var
 
 
 class ChatCompletionBase(ResponseModel):
@@ -35,8 +36,8 @@ class ChatCompletionAzure(ChatCompletionBase):
         """
         logging.info(f"Setting up AzureOpenAI LLM (model {model_name})")
         super().__init__(*args, **kwargs)
-        self.api_base = os.getenv("OPENAI_AZURE_API_BASE")
-        self.api_key = os.getenv("OPENAI_AZURE_API_KEY")
+        self.api_base = get_env_var("OPENAI_AZURE_API_BASE")
+        self.api_key = get_env_var("OPENAI_AZURE_API_KEY")
         self.api_type = "azure"
         self.api_version = "2023-03-15-preview"
         self.best_of = 1
@@ -133,7 +134,7 @@ class ChatCompletionOpenAI(ChatCompletionBase):
         """
         super().__init__(*args, **kwargs)
         self.model_name = model_name
-        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.api_key = get_env_var("OPENAI_API_KEY")
 
     def _respond(self, message: str, user_id: str) -> MessageResponse:
         """

--- a/reginald/models/models/chat_completion.py
+++ b/reginald/models/models/chat_completion.py
@@ -36,7 +36,7 @@ class ChatCompletionAzure(ChatCompletionBase):
         """
         logging.info(f"Setting up AzureOpenAI LLM (model {model_name})")
         super().__init__(*args, **kwargs)
-        self.api_base = get_env_var("OPENAI_AZURE_API_BASE")
+        self.api_base = get_env_var("OPENAI_AZURE_API_BASE", secret_value=False)
         self.api_key = get_env_var("OPENAI_AZURE_API_KEY")
         self.api_type = "azure"
         self.api_version = "2023-03-15-preview"

--- a/reginald/models/models/llama_index.py
+++ b/reginald/models/models/llama_index.py
@@ -569,7 +569,7 @@ class LlamaIndex(ResponseModel):
         else:
             logging.info("Loading the storage context")
             storage_context = StorageContext.from_defaults(
-                persist_dir=self.data_dir / LLAMA_INDEX_DIR / which_index
+                persist_dir=self.data_dir / LLAMA_INDEX_DIR / self.which_index
             )
 
             logging.info("Loading the pre-processed index")

--- a/reginald/models/models/llama_index.py
+++ b/reginald/models/models/llama_index.py
@@ -716,7 +716,7 @@ class LlamaIndexLlamaCPP(LlamaIndex):
         self.n_gpu_layers = n_gpu_layers
         super().__init__(*args, model_name=model_name, **kwargs)
 
-    def _prep_llm(self) -> LLM:
+    def _prep_llm(self) -> LlamaCPP:
         logging.info(
             f"Setting up LlamaCPP LLM (model {self.model_name}) on {self.n_gpu_layers} GPU layers"
         )
@@ -764,7 +764,7 @@ class LlamaIndexHF(LlamaIndex):
         self.device = device
         super().__init__(*args, model_name=model_name, **kwargs)
 
-    def _prep_llm(self) -> LLM:
+    def _prep_llm(self) -> HuggingFaceLLM:
         logging.info(
             f"Setting up Huggingface LLM (model {self.model_name}) on device {self.device}"
         )
@@ -807,7 +807,7 @@ class LlamaIndexGPTOpenAI(LlamaIndex):
         self.temperature = 0.7
         super().__init__(*args, model_name=self.model_name, **kwargs)
 
-    def _prep_llm(self) -> LLM:
+    def _prep_llm(self) -> OpenAI:
         logging.info(f"Setting up OpenAI LLM (model {self.model_name})")
         return OpenAI(
             model=self.model_name,
@@ -847,11 +847,11 @@ class LlamaIndexGPTAzure(LlamaIndex):
         self.deployment_name = model_name
         self.openai_api_base = os.getenv("OPENAI_AZURE_API_BASE")
         self.openai_api_key = os.getenv("OPENAI_AZURE_API_KEY")
-        self.openai_api_version = "2023-03-15-preview"
+        self.openai_api_version = "2023-09-15-preview"
         self.temperature = 0.7
         super().__init__(*args, model_name="gpt-3.5-turbo", **kwargs)
 
-    def _prep_llm(self) -> LLM:
+    def _prep_llm(self) -> AzureOpenAI:
         logging.info(f"Setting up AzureOpenAI LLM (model {self.deployment_name})")
         return AzureOpenAI(
             model=self.model_name,

--- a/reginald/models/models/llama_index.py
+++ b/reginald/models/models/llama_index.py
@@ -378,7 +378,9 @@ class DataIndexCreator:
                     "development",
                     "newsletters",
                     "objectives",
+                    "project-appraisal",
                     "rfc",
+                    "team-meetings",
                 ],  # we can adjust these
                 GithubRepositoryReader.FilterType.INCLUDE,
             ),

--- a/reginald/models/models/llama_index.py
+++ b/reginald/models/models/llama_index.py
@@ -875,11 +875,12 @@ class LlamaIndexGPTOpenAI(LlamaIndex):
         model_name : str, optional
             The model to use from the OpenAI API, by default "gpt-3.5-turbo"
         """
-        if os.getenv("OPENAI_API_KEY") is None:
+        openai_api_key = get_env_var("OPENAI_API_KEY")
+        if openai_api_key is None:
             raise ValueError("You must set OPENAI_API_KEY for OpenAI.")
 
         self.model_name = model_name
-        self.openai_api_key = get_env_var("OPENAI_API_KEY")
+        self.openai_api_key = openai_api_key
         self.temperature = 0.7
         super().__init__(*args, model_name=self.model_name, **kwargs)
 
@@ -911,18 +912,21 @@ class LlamaIndexGPTAzure(LlamaIndex):
         model_name : str, optional
             The deployment name of the model, by default "reginald-gpt35-turbo"
         """
-        if os.getenv("OPENAI_AZURE_API_BASE") is None:
+        openai_azure_api_base = get_env_var("OPENAI_AZURE_API_BASE", secret_value=False)
+        if openai_azure_api_base is None:
             raise ValueError(
                 "You must set OPENAI_AZURE_API_BASE to your Azure endpoint. "
                 "It should look like https://YOUR_RESOURCE_NAME.openai.azure.com/"
             )
-        if os.getenv("OPENAI_AZURE_API_KEY") is None:
+
+        openai_azure_api_key = get_env_var("OPENAI_AZURE_API_KEY")
+        if openai_azure_api_key is None:
             raise ValueError("You must set OPENAI_AZURE_API_KEY for Azure OpenAI.")
 
         # deployment name can be found in the Azure AI Studio portal
         self.deployment_name = model_name
-        self.openai_api_base = get_env_var("OPENAI_AZURE_API_BASE", secret_value=False)
-        self.openai_api_key = get_env_var("OPENAI_AZURE_API_KEY")
+        self.openai_api_base = openai_azure_api_base
+        self.openai_api_key = openai_azure_api_key
         self.openai_api_version = "2023-09-15-preview"
         self.temperature = 0.7
         super().__init__(*args, model_name="gpt-3.5-turbo", **kwargs)

--- a/reginald/models/models/llama_index.py
+++ b/reginald/models/models/llama_index.py
@@ -7,7 +7,7 @@ import pathlib
 import re
 import sys
 from tempfile import TemporaryDirectory
-from typing import Any, Optional
+from typing import Any
 
 import nest_asyncio
 import pandas as pd
@@ -39,13 +39,369 @@ from llama_index.readers import SimpleDirectoryReader
 from llama_index.response.schema import RESPONSE_TYPE
 
 from reginald.models.models.base import MessageResponse, ResponseModel
+from reginald.utils import get_env_var
 
 nest_asyncio.apply()
 
 
 LLAMA_INDEX_DIR = "llama_index_indices"
-PUBLIC_DATA_DIR = "public"
-INTERNAL_DATA_DIR = "turing_internal"
+
+
+def setup_service_context(
+    llm: LLM,
+    max_input_size: int,
+    num_output: int,
+    chunk_size: int,
+    chunk_overlap_ratio: float,
+) -> ServiceContext:
+    # initialise embedding model to use to create the index vectors
+    embed_model = HuggingFaceEmbeddings(
+        model_name="sentence-transformers/all-mpnet-base-v2"
+    )
+
+    # construct the prompt helper
+    prompt_helper = PromptHelper(
+        context_window=max_input_size,
+        num_output=num_output,
+        chunk_size_limit=chunk_size,
+        chunk_overlap_ratio=chunk_overlap_ratio,
+    )
+
+    # construct the service context
+    service_context = ServiceContext.from_defaults(
+        llm=llm,
+        embed_model=embed_model,
+        prompt_helper=prompt_helper,
+        chunk_size=chunk_size,
+    )
+
+    return service_context
+
+
+class DataIndexCreator:
+    def __init__(
+        self,
+        data_dir: pathlib.Path,
+        which_index: str,
+        service_context: ServiceContext,
+    ) -> None:
+        """
+        Class for creating the data index.
+
+        Parameters
+        ----------
+        data_dir : pathlib.Path
+            Path to the data directory.
+        which_index : str
+            Which index to construct (if force_new_index is True) or use.
+            Options are "handbook", "wikis",  "public", or "all_data".
+        service_context : ServiceContext
+            Service context to use to create the index.
+        """
+        self.data_dir: pathlib.Path = data_dir
+        self.which_index: str = which_index
+        self.service_context: ServiceContext = service_context
+        self.documents: list[str] = []
+        self.index: VectorStoreIndex | None = None
+
+    def prep_documents(self) -> None:
+        """
+        Method to prepare the documents for the index vector store.
+        """
+        # prep the contextual documents
+        gh_token = get_env_var("GITHUB_TOKEN")
+
+        if gh_token is None:
+            raise ValueError(
+                "Please export your github personal access token as 'GITHUB_TOKEN'."
+            )
+
+        if self.which_index == "handbook":
+            logging.info("Regenerating index only for the handbook")
+
+            # load handbook from repo
+            self._load_handbook(gh_token)
+
+        elif self.which_index == "wikis":
+            logging.info("Regenerating index only for the wikis")
+
+            # load wikis
+            self._load_wikis(gh_token)
+
+        elif self.which_index == "public":
+            logging.info("Regenerating index for all PUBLIC. Will take a long time...")
+
+            # load in scraped turing.ac.uk website
+            self._load_turing_ac_uk()
+
+            # load public data from repos
+            self._load_handbook(gh_token)
+            self._load_rse_course(gh_token)
+            self._load_rds_course(gh_token)
+            self._load_turing_way(gh_token)
+
+        elif self.which_index == "all_data":
+            logging.info("Regenerating index for ALL DATA. Will take a long time...")
+
+            # load in scraped turing.ac.uk website
+            self._load_turing_ac_uk()
+
+            # load public data from repos
+            self._load_handbook(gh_token)
+            self._load_rse_course(gh_token)
+            self._load_rds_course(gh_token)
+            self._load_turing_way(gh_token)
+
+            # load hut23 data
+            self._load_hut23(gh_token)
+
+            # load wikis
+            self._load_wikis(gh_token)
+
+        else:
+            logging.info("The which_index provided is unrecognized")
+
+    def _load_turing_ac_uk(self) -> None:
+        """
+        Load in the scraped turing.ac.uk website.
+
+        For 'public' index and 'all_data' index.
+        """
+        data_file = f"{self.data_dir}/public/turingacuk-no-boilerplate.csv"
+        turing_df = pd.read_csv(data_file)
+        turing_df = turing_df[~turing_df.loc[:, "body"].isna()]
+        self.documents += [
+            Document(text=row[1]["body"], extra_info={"url": row[1]["url"]})
+            for row in turing_df.iterrows()
+        ]
+
+    def _load_handbook(self, gh_token: str) -> None:
+        """
+        Load in the REG handbook.
+
+        For 'handbook' index, 'public' index, and 'all_data' index.
+
+        Parameters
+        ----------
+        gh_token : str
+            Github token to use to access the handbook repo.
+        """
+        owner = "alan-turing-institute"
+        repo = "REG-handbook"
+
+        handbook_loader = GithubRepositoryReader(
+            GithubClient(gh_token),
+            owner=owner,
+            repo=repo,
+            verbose=False,
+            filter_file_extensions=([".md"], GithubRepositoryReader.FilterType.INCLUDE),
+            filter_directories=(["content"], GithubRepositoryReader.FilterType.INCLUDE),
+        )
+        self.documents.extend(handbook_loader.load_data(branch="main"))
+
+    def _load_rse_course(self, gh_token: str) -> None:
+        """
+        Load in the REG RSE course.
+
+        For 'public' index and 'all_data' index.
+
+        Parameters
+        ----------
+        gh_token : str
+            Github token to use to access the RSE course repo.
+        """
+        owner = "alan-turing-institute"
+        repo = "rse-course"
+
+        rse_course_loader = GithubRepositoryReader(
+            GithubClient(gh_token),
+            owner=owner,
+            repo=repo,
+            verbose=False,
+            filter_file_extensions=(
+                [".md", ".ipynb"],
+                GithubRepositoryReader.FilterType.INCLUDE,
+            ),
+        )
+        self.documents.extend(rse_course_loader.load_data(branch="main"))
+
+    def _load_rds_course(self, gh_token: str) -> None:
+        """
+        Load in REG RDS course.
+
+        For 'public' index and 'all_data' index.
+
+        Parameters
+        ----------
+        gh_token : str
+            Github token to use to access the RDS course repo.
+        """
+        owner = "alan-turing-institute"
+        repo = "rds-course"
+
+        rds_course_loader = GithubRepositoryReader(
+            GithubClient(gh_token),
+            owner=owner,
+            repo=repo,
+            verbose=False,
+            filter_file_extensions=(
+                [".md", ".ipynb"],
+                GithubRepositoryReader.FilterType.INCLUDE,
+            ),
+        )
+        self.documents.extend(rds_course_loader.load_data(branch="develop"))
+
+    def _load_turing_way(self, gh_token: str) -> None:
+        """
+        Load in the Turing Way.
+
+        For 'public' index and 'all_data' index.
+
+        Parameters
+        ----------
+        gh_token : str
+            Github token to use to access the Turing Way repo.
+        """
+        owner = "the-turing-way"
+        repo = "the-turing-way"
+
+        turing_way_loader = GithubRepositoryReader(
+            GithubClient(gh_token),
+            owner=owner,
+            repo=repo,
+            verbose=False,
+            filter_file_extensions=([".md"], GithubRepositoryReader.FilterType.INCLUDE),
+        )
+        self.documents.extend(turing_way_loader.load_data(branch="main"))
+
+    def _load_hut23(self, gh_token: str) -> None:
+        """
+        Load in documents from the Hut23 repo.
+
+        For 'all_data' index.
+
+        Parameters
+        ----------
+        gh_token : str
+            Github token to use to access the Hut23 repo.
+        """
+        owner = "alan-turing-institute"
+        repo = "Hut23"
+
+        # load repo
+        hut23_repo_loader = GithubRepositoryReader(
+            GithubClient(gh_token),
+            owner=owner,
+            repo=repo,
+            verbose=False,
+            filter_file_extensions=(
+                [".md", ".ipynb"],
+                GithubRepositoryReader.FilterType.INCLUDE,
+            ),
+            filter_directories=(
+                [
+                    "JDs",
+                    "development",
+                    "newsletters",
+                    "objectives",
+                    "rfc",
+                ],  # we can adjust these
+                GithubRepositoryReader.FilterType.INCLUDE,
+            ),
+        )
+        self.documents.extend(hut23_repo_loader.load_data(branch="main"))
+
+        # load_issues
+        hut23_issues_loader = GitHubRepositoryIssuesReader(
+            GitHubIssuesClient(gh_token),
+            owner=owner,
+            repo=repo,
+            verbose=True,
+        )
+
+        issue_docs = hut23_issues_loader.load_data()
+        for doc in issue_docs:
+            doc.metadata["api_url"] = str(doc.metadata["url"])
+            doc.metadata["url"] = doc.metadata["source"]
+        self.documents.extend(issue_docs)
+
+        # load collaborators
+        # hut23_collaborators_loader = GitHubRepositoryCollaboratorsReader(
+        #     GitHubCollaboratorsClient(gh_token),
+        #     owner=owner,
+        #     repo=repo,
+        #     verbose=True,
+        # )
+        # self.documents.extend(hut23_collaborators_loader.load_data())
+
+    def _load_wikis(self, gh_token: str) -> None:
+        """
+        Load in documents from the wikis.
+
+        For 'wikis' index and 'all_data' index.
+        """
+        wiki_urls = [
+            "https://github.com/alan-turing-institute/research-engineering-group.wiki.git",
+            "https://github.com/alan-turing-institute/Hut23.wiki.git",
+        ]
+
+        for url in wiki_urls:
+            temp_dir = TemporaryDirectory()
+            wiki_path = os.path.join(temp_dir.name, url.split("/")[-1])
+
+            _ = Repo.clone_from(url, wiki_path)
+
+            reader = SimpleDirectoryReader(
+                input_dir=wiki_path,
+                required_exts=[".md"],
+                recursive=True,
+                filename_as_id=True,
+            )
+
+            # get base url and file names
+            base_url = url.removesuffix(".wiki.git")
+            fnames = [str(file) for file in reader.input_files]
+
+            # get file urls and create dictionary to map fname to url
+            file_urls = [
+                os.path.join(base_url, "wiki", fname.split("/")[-1].removesuffix(".md"))
+                for fname in fnames
+            ]
+            file_urls_dict = {
+                fname: file_url for fname, file_url in zip(fnames, file_urls)
+            }
+
+            def get_urls(fname):
+                return {"url": file_urls_dict.get(fname)}
+
+            # add `get_urls` function to reader
+            reader.file_metadata = get_urls
+
+            self.documents.extend(reader.load_data())
+
+    def create_index(self) -> VectorStoreIndex:
+        """
+        Create the index vector store.
+        """
+        # obtain documents
+        logging.info(f"Preparing documents for {self.which_index} index...")
+        self.prep_documents()
+
+        # create index
+        logging.info("Creating index...")
+        self.index = VectorStoreIndex.from_documents(
+            self.documents, service_context=self.service_context
+        )
+
+        return self.index
+
+    def save_index(self, directory: pathlib.Path | None = None) -> None:
+        if directory is None:
+            directory = self.data_dir / LLAMA_INDEX_DIR / self.which_index
+
+        # save the service context and persist the index
+        logging.info(f"Saving the index in {directory}...")
+        self.index.storage_context.persist(persist_dir=directory)
 
 
 class LlamaIndex(ResponseModel):
@@ -57,10 +413,10 @@ class LlamaIndex(ResponseModel):
         which_index: str,
         mode: str = "chat",
         k: int = 3,
-        chunk_size: Optional[int] = None,
+        chunk_size: int | None = None,
         chunk_overlap_ratio: float = 0.1,
-        force_new_index: bool = False,
         num_output: int = 512,
+        force_new_index: bool = False,
         *args,
         **kwargs,
     ) -> None:
@@ -84,17 +440,17 @@ class LlamaIndex(ResponseModel):
             The type of engine to use when interacting with the data, options of "chat" or "query".
             Default is "chat".
         k : int, optional
-            `similarity_top_k` to use in char or query engine, by default 3
-        chunk_size : Optional[int], optional
+            `similarity_top_k` to use in chat or query engine, by default 3
+        chunk_size : int | None, optional
             Maximum size of chunks to use, by default None.
             If None, this is computed as `ceil(max_input_size / k)`.
         chunk_overlap_ratio : float, optional
             Chunk overlap as a ratio of chunk size, by default 0.1
+        num_output : int, optional
+            Number of outputs for the LLM, by default 512
         force_new_index : bool, optional
             Whether or not to recreate the index vector store,
             by default False
-        num_output : int, optional
-            Number of outputs for the LLM, by default 512
         """
         super().__init__(*args, emoji="llama", **kwargs)
         logging.info("Setting up Huggingface backend.")
@@ -122,39 +478,24 @@ class LlamaIndex(ResponseModel):
         # set up LLM
         llm = self._prep_llm()
 
-        # initialise embedding model to use to create the index vectors
-        embed_model = HuggingFaceEmbeddings(
-            model_name="sentence-transformers/all-mpnet-base-v2"
-        )
-
-        # construct the prompt helper
-        prompt_helper = PromptHelper(
-            context_window=self.max_input_size,
-            num_output=self.num_output,
-            chunk_size_limit=self.chunk_size,
-            chunk_overlap_ratio=self.chunk_overlap_ratio,
-        )
-
-        # construct the service context
-        service_context = ServiceContext.from_defaults(
+        # set up service context
+        service_context = setup_service_context(
             llm=llm,
-            embed_model=embed_model,
-            prompt_helper=prompt_helper,
-            chunk_size=chunk_size,
+            max_input_size=self.max_input_size,
+            num_output=self.num_output,
+            chunk_size=self.chunk_size,
+            chunk_overlap_ratio=self.chunk_overlap_ratio,
         )
 
         if force_new_index:
             logging.info("Generating the index from scratch...")
-            self._prep_documents()
-            self.index = VectorStoreIndex.from_documents(
-                self.documents, service_context=service_context
+            data_creator = DataIndexCreator(
+                which_index=self.which_index,
+                data_dir=self.data_dir,
+                service_context=service_context,
             )
-
-            # save the service context and persist the index
-            logging.info("Saving the index")
-            self.index.storage_context.persist(
-                persist_dir=self.data_dir / LLAMA_INDEX_DIR / which_index
-            )
+            self.index = data_creator.create_index()
+            data_creator.save_index()
 
         else:
             logging.info("Loading the storage context")
@@ -271,222 +612,6 @@ class LlamaIndex(ResponseModel):
             )
             answer = formatted_response
         return answer
-
-    def _prep_documents(self):
-        """
-        Method to prepare the documents for the index vector store.
-
-        """
-        # Prep the contextual documents
-        gh_token = os.getenv("GITHUB_TOKEN")
-
-        if gh_token is None:
-            raise ValueError(
-                "Please export your github personal access token as 'GITHUB_TOKEN'."
-            )
-
-        if self.which_index == "handbook":
-            logging.info("Regenerating index only for the handbook")
-
-            # load handbook from repo
-            self._load_handbook(gh_token)
-
-        elif self.which_index == "wikis":
-            logging.info("Regenerating index only for the wikis")
-
-            # load wikis
-            self._load_wikis(gh_token)
-
-        elif self.which_index == "public":
-            logging.info("Regenerating index for all PUBLIC. Will take a long time...")
-
-            # load in scraped turing.ac.uk website
-            self._load_turing_ac_uk()
-
-            # load public data from repos
-            self._load_handbook(gh_token)
-            self._load_rse_course(gh_token)
-            self._load_rds_course(gh_token)
-            self._load_turing_way(gh_token)
-
-        elif self.which_index == "all_data":
-            logging.info("Regenerating index for ALL DATA. Will take a long time...")
-
-            # load in scraped turing.ac.uk website
-            self._load_turing_ac_uk()
-
-            # load public data from repos
-            self._load_handbook(gh_token)
-            self._load_rse_course(gh_token)
-            self._load_rds_course(gh_token)
-            self._load_turing_way(gh_token)
-
-            # load hut23 data
-            self._load_hut23(gh_token)
-
-            # load wikis
-            self._load_wikis(gh_token)
-
-        else:
-            logging.info("The data_files directory is unrecognized")
-
-    def _load_turing_ac_uk(self):
-        data_file = f"{self.data_dir}/public/turingacuk-no-boilerplate.csv"
-        turing_df = pd.read_csv(data_file)
-        turing_df = turing_df[~turing_df.loc[:, "body"].isna()]
-        self.documents += [
-            Document(text=row[1]["body"], extra_info={"url": row[1]["url"]})
-            for row in turing_df.iterrows()
-        ]
-
-    def _load_handbook(self, gh_token):
-        owner = "alan-turing-institute"
-        repo = "REG-handbook"
-
-        handbook_loader = GithubRepositoryReader(
-            GithubClient(gh_token),
-            owner=owner,
-            repo=repo,
-            verbose=False,
-            filter_file_extensions=([".md"], GithubRepositoryReader.FilterType.INCLUDE),
-            filter_directories=(["content"], GithubRepositoryReader.FilterType.INCLUDE),
-        )
-        self.documents.extend(handbook_loader.load_data(branch="main"))
-
-    def _load_rse_course(self, gh_token):
-        owner = "alan-turing-institute"
-        repo = "rse-course"
-
-        rse_course_loader = GithubRepositoryReader(
-            GithubClient(gh_token),
-            owner=owner,
-            repo=repo,
-            verbose=False,
-            filter_file_extensions=(
-                [".md", ".ipynb"],
-                GithubRepositoryReader.FilterType.INCLUDE,
-            ),
-        )
-        self.documents.extend(rse_course_loader.load_data(branch="main"))
-
-    def _load_rds_course(self, gh_token):
-        owner = "alan-turing-institute"
-        repo = "rds-course"
-
-        rds_course_loader = GithubRepositoryReader(
-            GithubClient(gh_token),
-            owner=owner,
-            repo=repo,
-            verbose=False,
-            filter_file_extensions=(
-                [".md", ".ipynb"],
-                GithubRepositoryReader.FilterType.INCLUDE,
-            ),
-        )
-        self.documents.extend(rds_course_loader.load_data(branch="develop"))
-
-    def _load_turing_way(self, gh_token):
-        owner = "the-turing-way"
-        repo = "the-turing-way"
-
-        turing_way_loader = GithubRepositoryReader(
-            GithubClient(gh_token),
-            owner=owner,
-            repo=repo,
-            verbose=False,
-            filter_file_extensions=([".md"], GithubRepositoryReader.FilterType.INCLUDE),
-        )
-        self.documents.extend(turing_way_loader.load_data(branch="main"))
-
-    def _load_hut23(self, gh_token):
-        owner = "alan-turing-institute"
-        repo = "Hut23"
-
-        # load repo
-        hut23_repo_loader = GithubRepositoryReader(
-            GithubClient(gh_token),
-            owner=owner,
-            repo=repo,
-            verbose=False,
-            filter_file_extensions=(
-                [".md", ".ipynb"],
-                GithubRepositoryReader.FilterType.INCLUDE,
-            ),
-            filter_directories=(
-                [
-                    "JDs",
-                    "development",
-                    "newsletters",
-                    "objectives",
-                    "rfc",
-                ],  # we can adjust these
-                GithubRepositoryReader.FilterType.INCLUDE,
-            ),
-        )
-        self.documents.extend(hut23_repo_loader.load_data(branch="main"))
-
-        # load_issues
-        hut23_issues_loader = GitHubRepositoryIssuesReader(
-            GitHubIssuesClient(gh_token),
-            owner=owner,
-            repo=repo,
-            verbose=True,
-        )
-
-        issue_docs = hut23_issues_loader.load_data()
-        for doc in issue_docs:
-            doc.metadata["api_url"] = str(doc.metadata["url"])
-            doc.metadata["url"] = doc.metadata["source"]
-        self.documents.extend(issue_docs)
-
-        # load collaborators
-        # hut23_collaborators_loader = GitHubRepositoryCollaboratorsReader(
-        #     GitHubCollaboratorsClient(gh_token),
-        #     owner=owner,
-        #     repo=repo,
-        #     verbose=True,
-        # )
-        # self.documents.extend(hut23_collaborators_loader.load_data())
-
-    def _load_wikis(self, gh_token):
-        wiki_urls = [
-            "https://github.com/alan-turing-institute/research-engineering-group.wiki.git",
-            "https://github.com/alan-turing-institute/Hut23.wiki.git",
-        ]
-
-        for url in wiki_urls:
-            temp_dir = TemporaryDirectory()
-            wiki_path = os.path.join(temp_dir.name, url.split("/")[-1])
-
-            _ = Repo.clone_from(url, wiki_path)
-
-            reader = SimpleDirectoryReader(
-                input_dir=wiki_path,
-                required_exts=[".md"],
-                recursive=True,
-                filename_as_id=True,
-            )
-
-            # get base url and file names
-            base_url = url.removesuffix(".wiki.git")
-            fnames = [str(file) for file in reader.input_files]
-
-            # get file urls and create dictionary to map fname to url
-            file_urls = [
-                os.path.join(base_url, "wiki", fname.split("/")[-1].removesuffix(".md"))
-                for fname in fnames
-            ]
-            file_urls_dict = {
-                fname: file_url for fname, file_url in zip(fnames, file_urls)
-            }
-
-            def get_urls(fname):
-                return {"url": file_urls_dict.get(fname)}
-
-            # add `get_urls` function to reader
-            reader.file_metadata = get_urls
-
-            self.documents.extend(reader.load_data())
 
     def _prep_llm(self) -> LLM:
         """

--- a/reginald/models/models/llama_index.py
+++ b/reginald/models/models/llama_index.py
@@ -803,7 +803,7 @@ class LlamaIndexGPTOpenAI(LlamaIndex):
             raise ValueError("You must set OPENAI_API_KEY for OpenAI.")
 
         self.model_name = model_name
-        self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        self.openai_api_key = get_env_var("OPENAI_API_KEY")
         self.temperature = 0.7
         super().__init__(*args, model_name=self.model_name, **kwargs)
 
@@ -845,8 +845,8 @@ class LlamaIndexGPTAzure(LlamaIndex):
 
         # deployment name can be found in the Azure AI Studio portal
         self.deployment_name = model_name
-        self.openai_api_base = os.getenv("OPENAI_AZURE_API_BASE")
-        self.openai_api_key = os.getenv("OPENAI_AZURE_API_KEY")
+        self.openai_api_base = get_env_var("OPENAI_AZURE_API_BASE")
+        self.openai_api_key = get_env_var("OPENAI_AZURE_API_KEY")
         self.openai_api_version = "2023-09-15-preview"
         self.temperature = 0.7
         super().__init__(*args, model_name="gpt-3.5-turbo", **kwargs)

--- a/reginald/models/models/llama_index.py
+++ b/reginald/models/models/llama_index.py
@@ -263,6 +263,7 @@ class DataIndexCreator:
             owner=owner,
             repo=repo,
             verbose=False,
+            concurrent_requests=1,
             filter_file_extensions=([".md"], GithubRepositoryReader.FilterType.INCLUDE),
             filter_directories=(["content"], GithubRepositoryReader.FilterType.INCLUDE),
         )
@@ -287,6 +288,7 @@ class DataIndexCreator:
             owner=owner,
             repo=repo,
             verbose=False,
+            concurrent_requests=1,
             filter_file_extensions=(
                 [".md", ".ipynb"],
                 GithubRepositoryReader.FilterType.INCLUDE,
@@ -313,6 +315,7 @@ class DataIndexCreator:
             owner=owner,
             repo=repo,
             verbose=False,
+            concurrent_requests=1,
             filter_file_extensions=(
                 [".md", ".ipynb"],
                 GithubRepositoryReader.FilterType.INCLUDE,
@@ -339,6 +342,7 @@ class DataIndexCreator:
             owner=owner,
             repo=repo,
             verbose=False,
+            concurrent_requests=1,
             filter_file_extensions=([".md"], GithubRepositoryReader.FilterType.INCLUDE),
         )
         self.documents.extend(turing_way_loader.load_data(branch="main"))
@@ -363,6 +367,7 @@ class DataIndexCreator:
             owner=owner,
             repo=repo,
             verbose=False,
+            concurrent_requests=1,
             filter_file_extensions=(
                 [".md", ".ipynb"],
                 GithubRepositoryReader.FilterType.INCLUDE,

--- a/reginald/models/models/llama_index.py
+++ b/reginald/models/models/llama_index.py
@@ -845,7 +845,7 @@ class LlamaIndexGPTAzure(LlamaIndex):
 
         # deployment name can be found in the Azure AI Studio portal
         self.deployment_name = model_name
-        self.openai_api_base = get_env_var("OPENAI_AZURE_API_BASE")
+        self.openai_api_base = get_env_var("OPENAI_AZURE_API_BASE", secret_value=False)
         self.openai_api_key = get_env_var("OPENAI_AZURE_API_KEY")
         self.openai_api_version = "2023-09-15-preview"
         self.temperature = 0.7

--- a/reginald/models/setup_llm.py
+++ b/reginald/models/setup_llm.py
@@ -28,13 +28,13 @@ def setup_llm(
     data_dir: str | None = None,
     which_index: str | None = None,
     force_new_index: bool | str | None = None,
-    max_input_size: int | None = None,
-    k: int | None = None,
-    chunk_size: int | None = None,
-    chunk_overlap_ratio: float | None = None,
-    num_output: int | None = None,
+    max_input_size: int | str | None = None,
+    k: int | str | None = None,
+    chunk_size: int | str | None = None,
+    chunk_overlap_ratio: float | str | None = None,
+    num_output: int | str | None = None,
     is_path: bool | str | None = None,
-    n_gpu_layers: int | None = None,
+    n_gpu_layers: int | str | None = None,
     device: str | None = None,
 ) -> ResponseModel:
     """
@@ -65,31 +65,37 @@ def setup_llm(
         Whether to recreate the index vector store or not, by default None
         (uses False). If this is a string, it is converted to a boolean
         using `force_new_index.lower() == "true"`.
-    max_input_size : int | None, optional
+    max_input_size : int | str | None, optional
         Select the maximum input size for the model, by default None
         (uses 4096). Ignored if not using "llama-index-llama-cpp" or
-        "llama-index-hf" models
-    k : int | None, optional
+        "llama-index-hf" models, If this is a string, it is converted
+        to an integer
+    k : int | str | None, optional
         `similarity_top_k` to use in chat or query engine,
-        by default None (uses 3)
-    chunk_size : int | None, optional
+        by default None (uses 3). If this is a string, it is converted
+        to an integer
+    chunk_size : int | str | None, optional
         Maximum size of chunks to use, by default None.
         If None, this is computed as `ceil(max_input_size / k)`.
-    chunk_overlap_ratio : float, optional
-        Chunk overlap as a ratio of chunk size, by default None (uses 0.1)
-    num_output : int | None, optional
-            Number of outputs for the LLM, by default None (uses 512)
+        If this is a string, it is converted to an integer
+    chunk_overlap_ratio : float | str | None, optional
+        Chunk overlap as a ratio of chunk size, by default None (uses 0.1).
+        If this is a string, it is converted to a float
+    num_output : int | str | None, optional
+        Number of outputs for the LLM, by default None (uses 512).
+        If this is a string, it is converted to an integer
     is_path : bool | str | None, optional
         Whether or not model_name is used as a path to the model file,
         otherwise it should be the URL to download the model,
         by default None (uses False). If this is a string, it is
         converted to a boolean using `is_path.lower() == "true"`.
         Ignored if not using "llama-index-llama-cpp" model
-    n_gpu_layers : int | None, optional
+    n_gpu_layers : int | str | None, optional
         Select the number of GPU layers to use. If -1, all layers are
         offloaded to the GPU. If 0, no layers are offloaded to the GPU,
         by default None (uses 0). Ignored if not using
-        "llama-index-llama-cpp" model
+        "llama-index-llama-cpp" model. If this is a string, it is
+        converted to an integer
     device : str | None, optional
         Select which device to use, by default None (uses "auto").
         Ignored if not using "llama-index-llama-cpp" or "llama-index-hf" models
@@ -138,18 +144,31 @@ def setup_llm(
     # default for max_input_size
     if max_input_size is None:
         max_input_size = DEFAULT_ARGS["max_input_size"]
+    if isinstance(max_input_size, str):
+        max_input_size = int(max_input_size)
 
     # default for k
     if k is None:
         k = DEFAULT_ARGS["k"]
+    if isinstance(k, str):
+        k = int(k)
+
+    # convert chunk_size if provided as str
+    # default is computed later using values of max_input_size and k
+    if isinstance(chunk_size, str):
+        chunk_size = int(chunk_size)
 
     # default for chunk_overlap_ratio
     if chunk_overlap_ratio is None:
         chunk_overlap_ratio = DEFAULT_ARGS["chunk_overlap_ratio"]
+    if isinstance(chunk_overlap_ratio, str):
+        chunk_overlap_ratio = float(chunk_overlap_ratio)
 
     # default for num_output
     if num_output is None:
         num_output = DEFAULT_ARGS["num_output"]
+    if isinstance(num_output, str):
+        num_output = int(num_output)
 
     # default for is_path
     if is_path is None:
@@ -160,6 +179,8 @@ def setup_llm(
     # default for n_gpu_layers
     if n_gpu_layers is None:
         n_gpu_layers = DEFAULT_ARGS["n_gpu_layers"]
+    if isinstance(n_gpu_layers, str):
+        n_gpu_layers = int(n_gpu_layers)
 
     # default for device
     if device is None:

--- a/reginald/models/setup_llm.py
+++ b/reginald/models/setup_llm.py
@@ -25,7 +25,7 @@ def setup_llm(
     model: str | None = None,
     model_name: str | None = None,
     mode: str | None = None,
-    data_dir: str | None = None,
+    data_dir: pathlib.Path | str | None = None,
     which_index: str | None = None,
     force_new_index: bool | str | None = None,
     max_input_size: int | str | None = None,
@@ -54,9 +54,10 @@ def setup_llm(
         Select which mode to use between "chat" and "query",
         by default None (uses "chat"). This is ignored if not using
         llama-index
-    data_dir : str | None, optional
+    data_dir : pathlib.Path | str | None, optional
         Location of the data, by default None
-        (uses the data directory in the root of the repo)
+        (uses the data directory in the root of the repo).
+        If this is a string, it is converted to a pathlib.Path
     which_index : str | None, optional
         Specifies the directory name for looking up/writing indices.
         Currently supports 'handbook', 'wikis', 'public', or 'all_data'.

--- a/reginald/parser_utils.py
+++ b/reginald/parser_utils.py
@@ -64,7 +64,11 @@ class Parser(argparse.ArgumentParser):
             self.add_argument(
                 "--force-new-index",
                 "-f",
-                help="Recreate the index vector store or not",
+                help=(
+                    "Recreate the index vector store or not "
+                    "(ignored if not using llama-index). "
+                    "Default is False."
+                ),
                 action=argparse.BooleanOptionalAction,
                 default=lambda: get_env_var("LLAMA_INDEX_FORCE_NEW_INDEX"),
             )
@@ -73,7 +77,8 @@ class Parser(argparse.ArgumentParser):
                 "-p",
                 help=(
                     "Whether or not the model_name passed is a path to the model "
-                    "(ignored if not using llama-index-llama-cpp)"
+                    "(ignored if not using llama-index-llama-cpp). "
+                    "Default is False."
                 ),
                 action=argparse.BooleanOptionalAction,
                 default=lambda: get_env_var("LLAMA_INDEX_IS_PATH"),
@@ -106,7 +111,10 @@ class Parser(argparse.ArgumentParser):
             "--data-dir",
             "-d",
             type=pathlib.Path,
-            help="Location for data",
+            help=(
+                "Location for data (ignored if not using llama-index). "
+                "Default is 'data' in the root of the repo."
+            ),
             default=lambda: get_env_var("LLAMA_INDEX_DATA_DIR")
             or (pathlib.Path(__file__).parent.parent / "data").resolve(),
         )
@@ -115,7 +123,8 @@ class Parser(argparse.ArgumentParser):
             "-w",
             type=str,
             help=(
-                "Specifies the directory name for looking up/writing indices. "
+                "Specifies the directory name for looking up/writing indices "
+                "(ignored if not using llama-index). "
                 "Currently supports 'handbook', 'wikis', 'public', or 'all_data'. "
                 "Default is 'all_data'."
             ),

--- a/reginald/parser_utils.py
+++ b/reginald/parser_utils.py
@@ -1,0 +1,176 @@
+import argparse
+import pathlib
+
+from reginald.models.models import MODELS
+from reginald.utils import get_env_var
+
+
+class Parser(argparse.ArgumentParser):
+    def __init__(self, create_index_only: bool = False, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not create_index_only:
+            # model args
+            self.add_argument(
+                "--model",
+                "-m",
+                help=("Select which type of model to use " "Default is 'hello'."),
+                default=lambda: get_env_var("REGINALD_MODEL"),
+                choices=MODELS,
+            )
+            self.add_argument(
+                "--model-name",
+                "-n",
+                type=str,
+                help=(
+                    "Select which sub-model to use (within the main model selected)."
+                    "For llama-index-llama-cpp and llama-index-hf models, this specifies"
+                    "the LLM (or path to that model) which we would like to use."
+                    "For chat-completion-azure and llama-index-gpt-azure, this refers"
+                    "to the deployment name on Azure."
+                    "For chat-completion-azure and llama-index-gpt-openai, this refers"
+                    "to the model name on OpenAI."
+                    "(ignored if using 'hello' model types)."
+                ),
+                default=lambda: get_env_var("REGINALD_MODEL_NAME"),
+            )
+            self.add_argument(
+                "--mode",
+                type=str,
+                help=(
+                    "Select which mode to use "
+                    "(ignored if not using llama-index). "
+                    "Default is 'chat'."
+                ),
+                default=lambda: get_env_var("LLAMA_INDEX_MODE"),
+                choices=["chat", "query"],
+            )
+            self.add_argument(
+                "--force-new-index",
+                "-f",
+                help="Recreate the index vector store or not",
+                action=argparse.BooleanOptionalAction,
+                default=lambda: get_env_var("LLAMA_INDEX_FORCE_NEW_INDEX"),
+            )
+            self.add_argument(
+                "--is-path",
+                "-p",
+                help=(
+                    "Whether or not the model_name passed is a path to the model "
+                    "(ignored if not using llama-index-llama-cpp)"
+                ),
+                action=argparse.BooleanOptionalAction,
+                default=lambda: get_env_var("LLAMA_INDEX_IS_PATH"),
+            )
+            self.add_argument(
+                "--n-gpu-layers",
+                "-ngl",
+                type=int,
+                help=(
+                    "Select number of GPU layers for LlamaCPP model "
+                    "(ignored if not using llama-index-llama-cpp). "
+                    "Default is 0."
+                ),
+                default=lambda: get_env_var("LLAMA_INDEX_N_GPU_LAYERS"),
+            )
+            self.add_argument(
+                "--device",
+                "-dev",
+                type=str,
+                help=(
+                    "Select device for HuggingFace model "
+                    "(ignored if not using llama-index-hf model). "
+                    "Default is 'auto'."
+                ),
+                default=lambda: get_env_var("LLAMA_INDEX_DEVICE"),
+            )
+
+        self.add_argument(
+            "--data-dir",
+            "-d",
+            type=pathlib.Path,
+            help="Location for data",
+            default=lambda: get_env_var("LLAMA_INDEX_DATA_DIR")
+            or (pathlib.Path(__file__).parent.parent / "data").resolve(),
+        )
+        self.add_argument(
+            "--which-index",
+            "-w",
+            type=str,
+            help=(
+                "Specifies the directory name for looking up/writing indices. "
+                "Currently supports 'handbook', 'wikis', 'public', or 'all_data'. "
+                "Default is 'all_data'."
+            ),
+            default=lambda: get_env_var("LLAMA_INDEX_WHICH_INDEX"),
+            choices=["handbook", "wikis", "public", "all_data"],
+        )
+        self.add_argument(
+            "--max-input-size",
+            "-max",
+            type=int,
+            help=(
+                "Select maximum input size for LlamaCPP or HuggingFace model "
+                "(ignored if not using llama-index). "
+                "Default is 4096."
+            ),
+            default=lambda: get_env_var("LLAMA_INDEX_MAX_INPUT_SIZE"),
+        )
+        self.add_argument(
+            "--k",
+            type=int,
+            help=(
+                "`similarity_top_k` to use in chat or query engine, "
+                "(ignored if not using llama-index). "
+                "Default is 3."
+            ),
+            default=lambda: get_env_var("LLAMA_INDEX_K"),
+        )
+        self.add_argument(
+            "--chunk-size",
+            "-cs",
+            type=int,
+            help=(
+                "Select chunk size for LlamaIndex model "
+                "(ignored if not using llama-index). "
+                "Default is computed by ceil(max_input_size / k)."
+            ),
+            default=lambda: get_env_var("LLAMA_INDEX_CHUNK_SIZE"),
+        )
+        self.add_argument(
+            "--chunk-overlap-ratio",
+            "-cor",
+            type=float,
+            help=(
+                "Select chunk overlap ratio for LlamaIndex model "
+                "(ignored if not using llama-index). "
+                "Default is 0.1."
+            ),
+            default=lambda: get_env_var("LLAMA_INDEX_CHUNK_OVERLAP_RATIO"),
+        )
+        self.add_argument(
+            "--num-output",
+            "-no",
+            type=int,
+            help=(
+                "Select number of outputs for LlamaIndex LLM model "
+                "(ignored if not using llama-index). "
+                "Default is 512."
+            ),
+            default=lambda: get_env_var("LLAMA_INDEX_NUM_OUTPUT"),
+        )
+
+
+def get_args(parser: Parser) -> argparse.Namespace:
+    # parse command line arguments
+    args = parser.parse_args()
+
+    # call any lambda functions in the args
+    for arg_name in vars(args):
+        arg_value = getattr(args, arg_name)
+        if callable(arg_value):
+            # call the lambda function to get its value
+            arg_value = arg_value()
+            # update the argument value in args
+            setattr(args, arg_name, arg_value)
+
+    return args

--- a/reginald/parser_utils.py
+++ b/reginald/parser_utils.py
@@ -2,6 +2,7 @@ import argparse
 import pathlib
 
 from reginald.models.models import MODELS
+from reginald.models.setup_llm import DEFAULT_ARGS
 from reginald.utils import get_env_var
 
 
@@ -32,7 +33,9 @@ class Parser(argparse.ArgumentParser):
                 "-m",
                 type=str,
                 help=("Select which type of model to use " "Default is 'hello'."),
-                default=lambda: get_env_var("REGINALD_MODEL", secret_value=False),
+                default=lambda: get_env_var(
+                    "REGINALD_MODEL", secret_value=False, default="hello"
+                ),
                 choices=MODELS,
             )
             self.add_argument(
@@ -95,8 +98,8 @@ class Parser(argparse.ArgumentParser):
                     "(ignored if not using llama-index-llama-cpp). "
                     "Default is 0."
                 ),
-                default=lambda: int(
-                    get_env_var("LLAMA_INDEX_N_GPU_LAYERS", secret_value=False)
+                default=lambda: get_env_var(
+                    "LLAMA_INDEX_N_GPU_LAYERS", secret_value=False
                 ),
             )
             self.add_argument(
@@ -145,8 +148,8 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 4096."
             ),
-            default=lambda: int(
-                get_env_var("LLAMA_INDEX_MAX_INPUT_SIZE", secret_value=False)
+            default=lambda: get_env_var(
+                "LLAMA_INDEX_MAX_INPUT_SIZE", secret_value=False
             ),
         )
         self.add_argument(
@@ -157,7 +160,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 3."
             ),
-            default=lambda: int(get_env_var("LLAMA_INDEX_K", secret_value=False)),
+            default=lambda: get_env_var("LLAMA_INDEX_K", secret_value=False),
         )
         self.add_argument(
             "--chunk-size",
@@ -168,9 +171,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is computed by ceil(max_input_size / k)."
             ),
-            default=lambda: int(
-                get_env_var("LLAMA_INDEX_CHUNK_SIZE", secret_value=False)
-            ),
+            default=lambda: get_env_var("LLAMA_INDEX_CHUNK_SIZE", secret_value=False),
         )
         self.add_argument(
             "--chunk-overlap-ratio",
@@ -181,8 +182,8 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 0.1."
             ),
-            default=lambda: float(
-                get_env_var("LLAMA_INDEX_CHUNK_OVERLAP_RATIO", secret_value=False)
+            default=lambda: get_env_var(
+                "LLAMA_INDEX_CHUNK_OVERLAP_RATIO", secret_value=False
             ),
         )
         self.add_argument(
@@ -194,9 +195,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 512."
             ),
-            default=lambda: int(
-                get_env_var("LLAMA_INDEX_NUM_OUTPUT", secret_value=False)
-            ),
+            default=lambda: get_env_var("LLAMA_INDEX_NUM_OUTPUT", secret_value=False),
         )
 
 

--- a/reginald/parser_utils.py
+++ b/reginald/parser_utils.py
@@ -30,6 +30,7 @@ class Parser(argparse.ArgumentParser):
             self.add_argument(
                 "--model",
                 "-m",
+                type=str,
                 help=("Select which type of model to use " "Default is 'hello'."),
                 default=lambda: get_env_var("REGINALD_MODEL"),
                 choices=MODELS,
@@ -92,7 +93,7 @@ class Parser(argparse.ArgumentParser):
                     "(ignored if not using llama-index-llama-cpp). "
                     "Default is 0."
                 ),
-                default=lambda: get_env_var("LLAMA_INDEX_N_GPU_LAYERS"),
+                default=lambda: int(get_env_var("LLAMA_INDEX_N_GPU_LAYERS")),
             )
             self.add_argument(
                 "--device",
@@ -140,7 +141,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 4096."
             ),
-            default=lambda: get_env_var("LLAMA_INDEX_MAX_INPUT_SIZE"),
+            default=lambda: int(get_env_var("LLAMA_INDEX_MAX_INPUT_SIZE")),
         )
         self.add_argument(
             "--k",
@@ -150,7 +151,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 3."
             ),
-            default=lambda: get_env_var("LLAMA_INDEX_K"),
+            default=lambda: int(get_env_var("LLAMA_INDEX_K")),
         )
         self.add_argument(
             "--chunk-size",
@@ -161,7 +162,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is computed by ceil(max_input_size / k)."
             ),
-            default=lambda: get_env_var("LLAMA_INDEX_CHUNK_SIZE"),
+            default=lambda: int(get_env_var("LLAMA_INDEX_CHUNK_SIZE")),
         )
         self.add_argument(
             "--chunk-overlap-ratio",
@@ -172,7 +173,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 0.1."
             ),
-            default=lambda: get_env_var("LLAMA_INDEX_CHUNK_OVERLAP_RATIO"),
+            default=lambda: float(get_env_var("LLAMA_INDEX_CHUNK_OVERLAP_RATIO")),
         )
         self.add_argument(
             "--num-output",
@@ -183,7 +184,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 512."
             ),
-            default=lambda: get_env_var("LLAMA_INDEX_NUM_OUTPUT"),
+            default=lambda: int(get_env_var("LLAMA_INDEX_NUM_OUTPUT")),
         )
 
 

--- a/reginald/parser_utils.py
+++ b/reginald/parser_utils.py
@@ -32,7 +32,7 @@ class Parser(argparse.ArgumentParser):
                 "-m",
                 type=str,
                 help=("Select which type of model to use " "Default is 'hello'."),
-                default=lambda: get_env_var("REGINALD_MODEL"),
+                default=lambda: get_env_var("REGINALD_MODEL", secret_value=False),
                 choices=MODELS,
             )
             self.add_argument(
@@ -49,7 +49,7 @@ class Parser(argparse.ArgumentParser):
                     "to the model name on OpenAI."
                     "(ignored if using 'hello' model types)."
                 ),
-                default=lambda: get_env_var("REGINALD_MODEL_NAME"),
+                default=lambda: get_env_var("REGINALD_MODEL_NAME", secret_value=False),
             )
             self.add_argument(
                 "--mode",
@@ -59,7 +59,7 @@ class Parser(argparse.ArgumentParser):
                     "(ignored if not using llama-index). "
                     "Default is 'chat'."
                 ),
-                default=lambda: get_env_var("LLAMA_INDEX_MODE"),
+                default=lambda: get_env_var("LLAMA_INDEX_MODE", secret_value=False),
                 choices=["chat", "query"],
             )
             self.add_argument(
@@ -71,7 +71,9 @@ class Parser(argparse.ArgumentParser):
                     "Default is False."
                 ),
                 action=argparse.BooleanOptionalAction,
-                default=lambda: get_env_var("LLAMA_INDEX_FORCE_NEW_INDEX"),
+                default=lambda: get_env_var(
+                    "LLAMA_INDEX_FORCE_NEW_INDEX", secret_value=False
+                ),
             )
             self.add_argument(
                 "--is-path",
@@ -82,7 +84,7 @@ class Parser(argparse.ArgumentParser):
                     "Default is False."
                 ),
                 action=argparse.BooleanOptionalAction,
-                default=lambda: get_env_var("LLAMA_INDEX_IS_PATH"),
+                default=lambda: get_env_var("LLAMA_INDEX_IS_PATH", secret_value=False),
             )
             self.add_argument(
                 "--n-gpu-layers",
@@ -93,7 +95,9 @@ class Parser(argparse.ArgumentParser):
                     "(ignored if not using llama-index-llama-cpp). "
                     "Default is 0."
                 ),
-                default=lambda: int(get_env_var("LLAMA_INDEX_N_GPU_LAYERS")),
+                default=lambda: int(
+                    get_env_var("LLAMA_INDEX_N_GPU_LAYERS", secret_value=False)
+                ),
             )
             self.add_argument(
                 "--device",
@@ -104,7 +108,7 @@ class Parser(argparse.ArgumentParser):
                     "(ignored if not using llama-index-hf model). "
                     "Default is 'auto'."
                 ),
-                default=lambda: get_env_var("LLAMA_INDEX_DEVICE"),
+                default=lambda: get_env_var("LLAMA_INDEX_DEVICE", secret_value=False),
             )
 
         # data index arguments
@@ -116,7 +120,7 @@ class Parser(argparse.ArgumentParser):
                 "Location for data (ignored if not using llama-index). "
                 "Default is 'data' in the root of the repo."
             ),
-            default=lambda: get_env_var("LLAMA_INDEX_DATA_DIR")
+            default=lambda: get_env_var("LLAMA_INDEX_DATA_DIR", secret_value=False)
             or (pathlib.Path(__file__).parent.parent / "data").resolve(),
         )
         self.add_argument(
@@ -129,7 +133,7 @@ class Parser(argparse.ArgumentParser):
                 "Currently supports 'handbook', 'wikis', 'public', or 'all_data'. "
                 "Default is 'all_data'."
             ),
-            default=lambda: get_env_var("LLAMA_INDEX_WHICH_INDEX"),
+            default=lambda: get_env_var("LLAMA_INDEX_WHICH_INDEX", secret_value=False),
             choices=["handbook", "wikis", "public", "all_data"],
         )
         self.add_argument(
@@ -141,7 +145,9 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 4096."
             ),
-            default=lambda: int(get_env_var("LLAMA_INDEX_MAX_INPUT_SIZE")),
+            default=lambda: int(
+                get_env_var("LLAMA_INDEX_MAX_INPUT_SIZE", secret_value=False)
+            ),
         )
         self.add_argument(
             "--k",
@@ -151,7 +157,7 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 3."
             ),
-            default=lambda: int(get_env_var("LLAMA_INDEX_K")),
+            default=lambda: int(get_env_var("LLAMA_INDEX_K", secret_value=False)),
         )
         self.add_argument(
             "--chunk-size",
@@ -162,7 +168,9 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is computed by ceil(max_input_size / k)."
             ),
-            default=lambda: int(get_env_var("LLAMA_INDEX_CHUNK_SIZE")),
+            default=lambda: int(
+                get_env_var("LLAMA_INDEX_CHUNK_SIZE", secret_value=False)
+            ),
         )
         self.add_argument(
             "--chunk-overlap-ratio",
@@ -173,7 +181,9 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 0.1."
             ),
-            default=lambda: float(get_env_var("LLAMA_INDEX_CHUNK_OVERLAP_RATIO")),
+            default=lambda: float(
+                get_env_var("LLAMA_INDEX_CHUNK_OVERLAP_RATIO", secret_value=False)
+            ),
         )
         self.add_argument(
             "--num-output",
@@ -184,7 +194,9 @@ class Parser(argparse.ArgumentParser):
                 "(ignored if not using llama-index). "
                 "Default is 512."
             ),
-            default=lambda: int(get_env_var("LLAMA_INDEX_NUM_OUTPUT")),
+            default=lambda: int(
+                get_env_var("LLAMA_INDEX_NUM_OUTPUT", secret_value=False)
+            ),
         )
 
 

--- a/reginald/parser_utils.py
+++ b/reginald/parser_utils.py
@@ -2,7 +2,6 @@ import argparse
 import pathlib
 
 from reginald.models.models import MODELS
-from reginald.models.setup_llm import DEFAULT_ARGS
 from reginald.utils import get_env_var
 
 
@@ -32,10 +31,8 @@ class Parser(argparse.ArgumentParser):
                 "--model",
                 "-m",
                 type=str,
-                help=("Select which type of model to use " "Default is 'hello'."),
-                default=lambda: get_env_var(
-                    "REGINALD_MODEL", secret_value=False, default="hello"
-                ),
+                help=("Select which type of model to use. Default is 'hello'."),
+                default=lambda: get_env_var("REGINALD_MODEL", secret_value=False),
                 choices=MODELS,
             )
             self.add_argument(

--- a/reginald/parser_utils.py
+++ b/reginald/parser_utils.py
@@ -21,7 +21,7 @@ class Parser(argparse.ArgumentParser):
         Parameters
         ----------
         create_index_only : bool, optional
-            Whether or not to only include ones related to data index creation,
+            Whether or not to only include arguments related to data index creation,
             by default False
         """
         super().__init__(*args, **kwargs)

--- a/reginald/parser_utils.py
+++ b/reginald/parser_utils.py
@@ -7,9 +7,26 @@ from reginald.utils import get_env_var
 
 class Parser(argparse.ArgumentParser):
     def __init__(self, create_index_only: bool = False, *args, **kwargs):
+        """
+        Parser for command line arguments for Reginald.
+
+        Note that the default values for the arguments are set to a lambda function
+        to obtain the relevant environment variables (if they exist). They are
+        lambda functions so that the environment variables are only obtained if
+        the argument is actually used.
+
+        See `get_args` for parsing the arguments and obtaining any of the
+        environment variables if using default values.
+
+        Parameters
+        ----------
+        create_index_only : bool, optional
+            Whether or not to only include ones related to data index creation,
+            by default False
+        """
         super().__init__(*args, **kwargs)
         if not create_index_only:
-            # model args
+            # model arguments
             self.add_argument(
                 "--model",
                 "-m",
@@ -84,6 +101,7 @@ class Parser(argparse.ArgumentParser):
                 default=lambda: get_env_var("LLAMA_INDEX_DEVICE"),
             )
 
+        # data index arguments
         self.add_argument(
             "--data-dir",
             "-d",
@@ -161,6 +179,20 @@ class Parser(argparse.ArgumentParser):
 
 
 def get_args(parser: Parser) -> argparse.Namespace:
+    """
+    Helper function to parse command line arguments and obtain any of the
+    environment variables if using default values.
+
+    Parameters
+    ----------
+    parser : Parser
+        Parser for command line arguments for Reginald
+
+    Returns
+    -------
+    argparse.Namespace
+        Namespace of parsed arguments
+    """
     # parse command line arguments
     args = parser.parse_args()
 

--- a/reginald/run.py
+++ b/reginald/run.py
@@ -2,17 +2,11 @@ import asyncio
 import logging
 
 from reginald.models.setup_llm import setup_llm
+from reginald.parser_utils import Parser, get_args
 from reginald.slack_bot.setup_bot import setup_slack_bot, setup_slack_client
-from reginald.utils import Parser
 
 
 async def main():
-    # parse command line arguments
-    parser = Parser()
-
-    # pass args to setup_llm
-    llm_kwargs = vars(parser.parse_args())
-
     # initialise logging
     logging.basicConfig(
         datefmt=r"%Y-%m-%d %H:%M:%S",
@@ -20,8 +14,14 @@ async def main():
         level=logging.INFO,
     )
 
+    # parse command line arguments
+    parser = Parser()
+
+    # pass args to setup_llm
+    args = get_args(parser)
+
     # set up response model
-    response_model = setup_llm(**llm_kwargs)
+    response_model = setup_llm(**vars(args))
 
     # set up slack bot
     bot = setup_slack_bot(response_model)

--- a/reginald/slack_bot/setup_bot.py
+++ b/reginald/slack_bot/setup_bot.py
@@ -32,7 +32,7 @@ def setup_slack_bot(model: ResponseModel) -> Bot:
     slack_bot = Bot(model=model)
 
     logging.info("Connecting to Slack...")
-    if os.environ.get("SLACK_APP_TOKEN") is None:
+    if os.getenv("SLACK_APP_TOKEN") is None:
         logging.error("SLACK_APP_TOKEN is not set")
         sys.exit(1)
 
@@ -60,7 +60,7 @@ def setup_api_slack_bot(api_url: str, emoji: str) -> ApiBot:
     slack_bot = ApiBot(api_url=api_url, emoji=emoji)
 
     logging.info("Connecting to Slack...")
-    if os.environ.get("SLACK_APP_TOKEN") is None:
+    if os.getenv("SLACK_APP_TOKEN") is None:
         logging.error("SLACK_APP_TOKEN is not set")
         sys.exit(1)
 
@@ -85,10 +85,10 @@ def setup_slack_client(slack_bot: ApiBot | Bot) -> SocketModeClient:
     SocketModeClient
         Slack client with bot
     """
-    if os.environ.get("SLACK_APP_TOKEN") is None:
+    if os.getenv("SLACK_APP_TOKEN") is None:
         logging.error("SLACK_APP_TOKEN is not set")
         sys.exit(1)
-    if os.environ.get("SLACK_BOT_TOKEN") is None:
+    if os.getenv("SLACK_BOT_TOKEN") is None:
         logging.error("SLACK_BOT_TOKEN is not set")
         sys.exit(1)
 

--- a/reginald/slack_bot/setup_bot.py
+++ b/reginald/slack_bot/setup_bot.py
@@ -32,7 +32,7 @@ def setup_slack_bot(model: ResponseModel) -> Bot:
     slack_bot = Bot(model=model)
 
     logging.info("Connecting to Slack...")
-    if get_env_var("SLACK_APP_TOKEN") is None:
+    if get_env_var("SLACK_APP_TOKEN", log=False) is None:
         logging.error("SLACK_APP_TOKEN is not set")
         sys.exit(1)
 
@@ -60,7 +60,7 @@ def setup_api_slack_bot(api_url: str, emoji: str) -> ApiBot:
     slack_bot = ApiBot(api_url=api_url, emoji=emoji)
 
     logging.info("Connecting to Slack...")
-    if get_env_var("SLACK_APP_TOKEN") is None:
+    if get_env_var("SLACK_APP_TOKEN", log=False) is None:
         logging.error("SLACK_APP_TOKEN is not set")
         sys.exit(1)
 

--- a/reginald/slack_bot/setup_bot.py
+++ b/reginald/slack_bot/setup_bot.py
@@ -142,7 +142,7 @@ async def main():
             "Select the emoji for the model. By default, looks for the REGINALD_EMOJI "
             "environment variable or uses the rocket emoji"
         ),
-        default=lambda: get_env_var("REGINALD_EMOJI") or "rocket",
+        default=lambda: get_env_var("REGINALD_EMOJI", secret_value=False) or "rocket",
     )
     args = get_args(parser)
 

--- a/reginald/slack_bot/setup_bot.py
+++ b/reginald/slack_bot/setup_bot.py
@@ -127,6 +127,7 @@ async def main():
     parser.add_argument(
         "--api-url",
         "-a",
+        type=str,
         help=(
             "Select the API URL for the model. If not set, "
             "must be set as the REGINALD_API_URL environment variable"
@@ -136,6 +137,7 @@ async def main():
     parser.add_argument(
         "--emoji",
         "-e",
+        type=str,
         help=(
             "Select the emoji for the model. By default, looks for the REGINALD_EMOJI "
             "environment variable or uses the rocket emoji"

--- a/reginald/slack_bot/setup_bot.py
+++ b/reginald/slack_bot/setup_bot.py
@@ -32,7 +32,7 @@ def setup_slack_bot(model: ResponseModel) -> Bot:
     slack_bot = Bot(model=model)
 
     logging.info("Connecting to Slack...")
-    if os.getenv("SLACK_APP_TOKEN") is None:
+    if get_env_var("SLACK_APP_TOKEN") is None:
         logging.error("SLACK_APP_TOKEN is not set")
         sys.exit(1)
 
@@ -60,7 +60,7 @@ def setup_api_slack_bot(api_url: str, emoji: str) -> ApiBot:
     slack_bot = ApiBot(api_url=api_url, emoji=emoji)
 
     logging.info("Connecting to Slack...")
-    if os.getenv("SLACK_APP_TOKEN") is None:
+    if get_env_var("SLACK_APP_TOKEN") is None:
         logging.error("SLACK_APP_TOKEN is not set")
         sys.exit(1)
 
@@ -85,19 +85,22 @@ def setup_slack_client(slack_bot: ApiBot | Bot) -> SocketModeClient:
     SocketModeClient
         Slack client with bot
     """
-    if os.getenv("SLACK_APP_TOKEN") is None:
+    slack_app_token = get_env_var("SLACK_APP_TOKEN")
+    if slack_app_token is None:
         logging.error("SLACK_APP_TOKEN is not set")
         sys.exit(1)
-    if os.getenv("SLACK_BOT_TOKEN") is None:
+
+    slack_bot_token = get_env_var("SLACK_BOT_TOKEN")
+    if slack_bot_token is None:
         logging.error("SLACK_BOT_TOKEN is not set")
         sys.exit(1)
 
     # initialize SocketModeClient with an app-level token + AsyncWebClient
     client = SocketModeClient(
         # this app-level token will be used only for establishing a connection
-        app_token=get_env_var("SLACK_APP_TOKEN"),
+        app_token=slack_app_token,
         # you will be using this AsyncWebClient for performing Web API calls in listeners
-        web_client=AsyncWebClient(token=get_env_var("SLACK_BOT_TOKEN")),
+        web_client=AsyncWebClient(token=slack_bot_token),
         # to ensure connection doesn't go stale - we can adjust as needed.
         ping_interval=60,
     )

--- a/reginald/utils.py
+++ b/reginald/utils.py
@@ -20,7 +20,7 @@ def get_env_var(var: str, log: bool = True) -> str | None:
     """
     if log:
         logging.info(f"Trying to get environment variable '{var}'")
-    value = os.environ.get(var)
+    value = os.getenv(var)
 
     if log:
         if value is None:
@@ -28,6 +28,6 @@ def get_env_var(var: str, log: bool = True) -> str | None:
                 f"Environment variable '{var}' not found. Can ignore if using default values."
             )
         else:
-            logging.info(f"Got environment variable '{var}': {value}")
+            logging.info(f"Got environment variable '{var}' successfully")
 
     return value

--- a/reginald/utils.py
+++ b/reginald/utils.py
@@ -2,7 +2,9 @@ import logging
 import os
 
 
-def get_env_var(var: str, log: bool = True, secret_value: bool = True) -> str | None:
+def get_env_var(
+    var: str, log: bool = True, secret_value: bool = True, default: str = None
+) -> str | None:
     """
     Get environment variable. Logs provided if log is True.
 
@@ -16,6 +18,8 @@ def get_env_var(var: str, log: bool = True, secret_value: bool = True) -> str | 
         Whether or not the value is a secret, by default True.
         If True, the value will not be logged.
         Ignored if log is False.
+    default : str, optional
+        Default value if environment variable is not found, by default None
 
     Returns
     -------
@@ -24,7 +28,7 @@ def get_env_var(var: str, log: bool = True, secret_value: bool = True) -> str | 
     """
     if log:
         logging.info(f"Trying to get environment variable '{var}'")
-    value = os.getenv(var)
+    value = os.getenv(var, default=default)
 
     if log:
         if value is not None:

--- a/reginald/utils.py
+++ b/reginald/utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 
-def get_env_var(var: str, log: bool = True) -> str | None:
+def get_env_var(var: str, log: bool = True, secret_value: bool = True) -> str | None:
     """
     Get environment variable. Logs provided if log is True.
 
@@ -12,6 +12,10 @@ def get_env_var(var: str, log: bool = True) -> str | None:
         Name of environment variable
     log : bool, optional
         Whether or not to log if reading was successful, by default True
+    secret_value : bool, optional
+        Whether or not the value is a secret, by default True.
+        If True, the value will not be logged.
+        Ignored if log is False.
 
     Returns
     -------
@@ -23,11 +27,14 @@ def get_env_var(var: str, log: bool = True) -> str | None:
     value = os.getenv(var)
 
     if log:
-        if value is None:
+        if value is not None:
+            if secret_value:
+                logging.info(f"Got environment variable '{var}' successfully")
+            else:
+                logging.info(f"Got environment variable '{var}' successfully: {value}")
+        else:
             logging.warn(
                 f"Environment variable '{var}' not found. Can ignore if using default values."
             )
-        else:
-            logging.info(f"Got environment variable '{var}' successfully")
 
     return value

--- a/reginald/utils.py
+++ b/reginald/utils.py
@@ -37,8 +37,6 @@ def get_env_var(
             else:
                 logging.info(f"Got environment variable '{var}' successfully: {value}")
         else:
-            logging.warn(
-                f"Environment variable '{var}' not found. Can ignore if using default values."
-            )
+            logging.warn(f"Environment variable '{var}' not found.")
 
     return value

--- a/reginald/utils.py
+++ b/reginald/utils.py
@@ -1,116 +1,33 @@
-import argparse
+import logging
 import os
-import pathlib
-
-from reginald.models.models import MODELS
 
 
-class Parser(argparse.ArgumentParser):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+def get_env_var(var: str, log: bool = True) -> str | None:
+    """
+    Get environment variable. Logs provided if log is True.
 
-        # model args
-        self.add_argument(
-            "--model",
-            "-m",
-            help=("Select which type of model to use " "Default is 'hello'."),
-            default=os.environ.get("REGINALD_MODEL"),
-            choices=MODELS,
-        )
-        self.add_argument(
-            "--model-name",
-            "-n",
-            type=str,
-            help=(
-                "Select which sub-model to use (within the main model selected)."
-                "For llama-index-llama-cpp and llama-index-hf models, this specifies"
-                "the LLM (or path to that model) which we would like to use."
-                "For chat-completion-azure and llama-index-gpt-azure, this refers"
-                "to the deployment name on Azure."
-                "For chat-completion-azure and llama-index-gpt-openai, this refers"
-                "to the model name on OpenAI."
-                "(ignored if using 'hello' model types)."
-            ),
-            default=os.environ.get("REGINALD_MODEL_NAME"),
-        )
-        self.add_argument(
-            "--mode",
-            type=str,
-            help=(
-                "Select which mode to use "
-                "(ignored if not using llama-index). "
-                "Default is 'chat'."
-            ),
-            default=os.environ.get("LLAMA_INDEX_MODE"),
-            choices=["chat", "query"],
-        )
-        self.add_argument(
-            "--data-dir",
-            "-d",
-            type=pathlib.Path,
-            help="Location for data",
-            default=os.environ.get("LLAMA_INDEX_DATA_DIR")
-            or (pathlib.Path(__file__).parent.parent / "data").resolve(),
-        )
-        self.add_argument(
-            "--which-index",
-            "-w",
-            type=str,
-            help=(
-                "Specifies the directory name for looking up/writing indices. "
-                "Currently supports 'handbook', 'wikis', 'public', or 'all_data'. "
-                "Default is 'all_data'."
-            ),
-            default=os.environ.get("LLAMA_INDEX_WHICH_INDEX"),
-            choices=["handbook", "wikis", "public", "all_data"],
-        )
-        self.add_argument(
-            "--force-new-index",
-            "-f",
-            help="Recreate the index vector store or not",
-            action=argparse.BooleanOptionalAction,
-            default=os.environ.get("LLAMA_INDEX_FORCE_NEW_INDEX"),
-        )
-        self.add_argument(
-            "--max-input-size",
-            "-max",
-            type=int,
-            help=(
-                "Select maximum input size for LlamaCPP or HuggingFace model "
-                "(ignored if not using llama-index-llama-cpp or llama-index-hf). "
-                "Default is 4096."
-            ),
-            default=os.environ.get("LLAMA_INDEX_MAX_INPUT_SIZE"),
-        )
-        self.add_argument(
-            "--is-path",
-            "-p",
-            help=(
-                "Whether or not the model_name passed is a path to the model "
-                "(ignored if not using llama-index-llama-cpp)"
-            ),
-            action=argparse.BooleanOptionalAction,
-            default=os.environ.get("LLAMA_INDEX_IS_PATH"),
-        )
-        self.add_argument(
-            "--n-gpu-layers",
-            "-ngl",
-            type=int,
-            help=(
-                "Select number of GPU layers for LlamaCPP model "
-                "(ignored if not using llama-index-llama-cpp). "
-                "Default is 0."
-            ),
-            default=os.environ.get("LLAMA_INDEX_N_GPU_LAYERS"),
-        )
-        self.add_argument(
-            "--device",
-            "-dev",
-            type=str,
-            help=(
-                "Select device for HuggingFace model "
-                "(ignored if not using llama-index-hf model). "
-                "Default is 'auto'."
-            ),
-            default=os.environ.get("LLAMA_INDEX_DEVICE"),
-        )
+    Parameters
+    ----------
+    var : str
+        Name of environment variable
+    log : bool, optional
+        Whether or not to log if reading was successful, by default True
+
+    Returns
+    -------
+    str | None
+        Value of environment variable, or None if not found
+    """
+    if log:
+        logging.info(f"Trying to get environment variable '{var}'")
+    value = os.environ.get(var)
+
+    if log:
+        if value is None:
+            logging.warn(
+                f"Environment variable '{var}' not found. Can ignore if using default values."
+            )
+        else:
+            logging.info(f"Got environment variable '{var}': {value}")
+
+    return value


### PR DESCRIPTION
For #143:
- Create `reginald_create_index` CLI to create an index
- Create Dockerfile for `reginald_create_index`
- Split up data index creation from `LlamaIndex` to make a `DataIndexCreator` class
- Also add a `setup_service_context` helper function which gets called in both setting up LlamaIndex model and when creating the index on its own
- Some more logging with the parser
  - Created `get_env_var` helper function which just logs when it's trying to read a environment variable and says if it's able to find it. If not able to, default arguments are used
  - I made the default arguments in argparses lambda functions so that we only try to get environment variables if they are needed (a bit of a hack because otherwise, it'd log that it's trying to find an environment variable even if we pass in a value for the CLI argument)
  - `get_args` loops through the arguments and calls the arguments and calls any lambda functions to get the default arguments
- `k`, `chunk_size`, `chunk_overlap_ratio`, `num_output` are now able to be passed as CLI arguments in `reginald_run`, `reginald_run_api_llm` and `reginald_create_index`