### PR TITLE
Add POST versions of the message endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ authors = ["Evelina Gabasova <evelina@evelinag.com>",
            "Tomas Lazauskas <tlazauskas@turing.ac.uk>",
            "David Beavan <dbeavan@turing.ac.uk>",
            "Levan Bokeria <lbokeria@turing.ac.uk>",
-           "Martin O'Reilly <moreilly@turing.ac.uk>"]
+           "Martin O'Reilly <moreilly@turing.ac.uk>",
+           "Oliver Strickson <ostrickson@turing.ac.uk>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/reginald/models/app.py
+++ b/reginald/models/app.py
@@ -47,13 +47,28 @@ def main():
         return "pong"
 
     # set up direct_message endpoint
+    #
+    # See the note on the below 'POST' endpoint and consider deprecating
     @app.get("/direct_message")
     async def direct_message(query: Query):
-        response = response_model.direct_message(query.message, query.user_id)
-        return response
+        return response_model.direct_message(query.message, query.user_id)
+
+    # A POST direct_message endpoint, equivalent to the above.
+    # This provides a version of the endpoint that avoids a surprising use of
+    # the message body for a GET request.  Provided as an additional endpoint
+    # instead of replacing the GET endpoint to avoid breaking things.
+    @app.post("/direct_message")
+    async def direct_message(query: Query):
+        return response_model.direct_message(query.message, query.user_id)
 
     # set up channel_mention endpoint
     @app.get("/channel_mention")
+    async def channel_mention(query: Query):
+        response = response_model.channel_mention(query.message, query.user_id)
+        return response
+
+    # POST channel_mention endpoint: see comment on direct_message
+    @app.post("/channel_mention")
     async def channel_mention(query: Query):
         response = response_model.channel_mention(query.message, query.user_id)
         return response


### PR DESCRIPTION
These add versions of the `direct_message` and `channel_mention` accepting POST requests.  The motivation is that the current GET endpoints look at the request body, which is unconventional, and not all http libraries support it.

The GET endpoints are unchanged so as not to break anything (like the Slackbot).
